### PR TITLE
Software renderer big endian fixes

### DIFF
--- a/core/inc/compiler.h
+++ b/core/inc/compiler.h
@@ -114,8 +114,12 @@ typedef float br_float;
  */
 #pragma off (unreferenced);
 
+#ifndef BR_ENDIAN_BIG
 #define BR_ENDIAN_BIG		0
+#endif
+#ifndef BR_ENDIAN_LITTLE
 #define BR_ENDIAN_LITTLE	1
+#endif
 
 #ifndef __H2INC__
 #pragma pack(4);
@@ -160,8 +164,12 @@ typedef float br_float;
 
 #define BR_HAS_FAR	0
 
+#ifndef BR_ENDIAN_BIG
 #define BR_ENDIAN_BIG		0
+#endif
+#ifndef BR_ENDIAN_LITTLE
 #define BR_ENDIAN_LITTLE	1
+#endif
 
 #ifndef __H2INC__
 #pragma warning(disable:4103)
@@ -208,8 +216,12 @@ typedef float br_float;
 
 #define BR_HAS_FAR	0
 
+#ifndef BR_ENDIAN_BIG
 #define BR_ENDIAN_BIG		0
+#endif
+#ifndef BR_ENDIAN_LITTLE
 #define BR_ENDIAN_LITTLE	1
+#endif
 
 #ifndef __H2INC__
 #pragma option -a4
@@ -255,8 +267,12 @@ typedef float br_float;
 
 #define BR_HAS_FAR	0
 
+#ifndef BR_ENDIAN_BIG
 #define BR_ENDIAN_BIG		0
+#endif
+#ifndef BR_ENDIAN_LITTLE
 #define BR_ENDIAN_LITTLE	1
+#endif
 
 /*
  * IBM CSet++
@@ -297,8 +313,12 @@ typedef float br_float;
 
 #define BR_HAS_FAR	0
 
+#ifndef BR_ENDIAN_BIG
 #define BR_ENDIAN_BIG		0
+#endif
+#ifndef BR_ENDIAN_LITTLE
 #define BR_ENDIAN_LITTLE	1
+#endif
 
 /*
  * Intel reference compiler
@@ -342,8 +362,12 @@ typedef float br_float;
 
 #define BR_HAS_FAR	0
 
+#ifndef BR_ENDIAN_BIG
 #define BR_ENDIAN_BIG		0
+#endif
+#ifndef BR_ENDIAN_LITTLE
 #define BR_ENDIAN_LITTLE	1
+#endif
 
 #endif
 

--- a/core/v1db/v1dbfile.c
+++ b/core/v1db/v1dbfile.c
@@ -538,6 +538,9 @@ static int FopRead_OLD_FACES_1(br_datafile *df, br_uint_32 id, br_uint_32 length
 	 * Convert smoothing groups to bitmask
 	 */
 	for(i=0; i< mp->nfaces; i++) {
+#if BR_ENDIAN_BIG
+		mp->faces[i].smoothing >>= 8;
+#endif
 		if(mp->faces[i].smoothing == 0)
 			mp->faces[i].smoothing = (br_uint_16)~0;
 		else
@@ -1009,6 +1012,9 @@ static int FopRead_MATERIAL_OLDEST(br_datafile *df, br_uint_32 id, br_uint_32 le
 	mp = BrMaterialAllocate(NULL);
 	df->res = mp;
     df->prims->struct_read(df,&br_material_oldest_F, mp);
+#if BR_ENDIAN_BIG
+	mp->flags >>= 16;
+#endif
 	df->res = NULL;
 
 	/*

--- a/drivers/pentprim/fpsetup.h
+++ b/drivers/pentprim/fpsetup.h
@@ -46,6 +46,7 @@ void TriangleSetup_ZT_ARBITRARY(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2);
 void TriangleSetup_ZTI_ARBITRARY(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2);
 
 // was a macro. Used by pfpsetup
-void SETUP_FLOAT_PARAM(int comp, char *param /*unused*/, uint32_t *s_p, uint32_t *d_p_x, uint32_t conv, int is_unsigned);
+typedef union fp64_t fp64_t;
+void SETUP_FLOAT_PARAM(int comp, char *param /*unused*/, fp64_t *s_p, fp64_t *d_p_x, uint32_t conv, int is_unsigned);
 
 #endif

--- a/drivers/pentprim/fpwork.h
+++ b/drivers/pentprim/fpwork.h
@@ -15,57 +15,220 @@ typedef struct counts_tag_t {
     } data;
 } counts_tag_t;
 
+typedef union fp64_t {
+    struct {
+#if BR_ENDIAN_BIG
+        uint32_t dword_high;
+        uint32_t dword_low;
+#else
+        uint32_t dword_low;
+        uint32_t dword_high;
+#endif
+    };
+    double double_val;
+} fp64_t;
+
 struct ALIGN(8) workspace_t {
     // qwords start here
 
-    uint32_t xm;
-    uint32_t d_xm;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t d_xm;
+			uint32_t xm;
+#else
+			uint32_t xm;
+			uint32_t d_xm;
+#endif
+		};
+		double xm_double;
+	};
 
-    uint32_t x1;
-    uint32_t d_x1;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t d_x1;
+			uint32_t x1;
+#else
+			uint32_t x1;
+			uint32_t d_x1;
+#endif
+		};
+		double x1_double;
+	};
 
-    uint32_t x2;
-    uint32_t d_x2;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t d_x2;
+			uint32_t x2;
+#else
+			uint32_t x2;
+			uint32_t d_x2;
+#endif
+		};
+		double x2_double;
+	};
 
-    uint32_t s_z;
-    uint32_t d_z_y_1;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t d_z_y_1;
+			uint32_t s_z;
+#else
+			uint32_t s_z;
+			uint32_t d_z_y_1;
+#endif
+		};
+		double s_z_double;
+	};
 
-    uint32_t d_z_x;
-    uint32_t d_z_y_0;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t d_z_y_0;
+			uint32_t d_z_x;
+#else
+			uint32_t d_z_x;
+			uint32_t d_z_y_0;
+#endif
+		};
+		double d_z_x_double;
+	};
 
-    uint32_t s_i;
-    uint32_t d_i_y_1;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t d_i_y_1;
+			uint32_t s_i;
+#else
+			uint32_t s_i;
+			uint32_t d_i_y_1;
+#endif
+		};
+		double s_i_double;
+	};
 
-    uint32_t d_i_x;
-    uint32_t d_i_y_0;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t d_i_y_0;
+			uint32_t d_i_x;
+#else
+			uint32_t d_i_x;
+			uint32_t d_i_y_0;
+#endif
+		};
+		double d_i_x_double;
+	};
 
-    uint32_t s_u;
-    uint32_t d_u_y_1;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t d_u_y_1;
+			uint32_t s_u;
+#else
+			uint32_t s_u;
+			uint32_t d_u_y_1;
+#endif
+		};
+		double s_u_double;
+	};
 
-    uint32_t d_u_x;
-    uint32_t d_u_y_0;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t d_u_y_0;
+			uint32_t d_u_x;
+#else
+			uint32_t d_u_x;
+			uint32_t d_u_y_0;
+#endif
+		};
+		double d_u_x_double;
+	};
 
-    uint32_t s_v;
-    uint32_t d_v_y_1;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t d_v_y_1;
+			uint32_t s_v;
+#else
+			uint32_t s_v;
+			uint32_t d_v_y_1;
+#endif
+		};
+		double s_v_double;
+	};
 
-    uint32_t d_v_x;
-    uint32_t d_v_y_0;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t d_v_y_0;
+			uint32_t d_v_x;
+#else
+			uint32_t d_v_x;
+			uint32_t d_v_y_0;
+#endif
+		};
+		double d_v_x_double;
+	};
 
-    uint32_t s_s;
-    uint32_t d_s_y_1;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t d_s_y_1;
+			uint32_t s_s;
+#else
+			uint32_t s_s;
+			uint32_t d_s_y_1;
+#endif
+		};
+		double s_s_double;
+	};
 
-    uint32_t d_s_x;
-    uint32_t d_s_y_0;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t d_s_y_0;
+			uint32_t d_s_x;
+#else
+			uint32_t d_s_x;
+			uint32_t d_s_y_0;
+#endif
+		};
+		double d_s_x_double;
+	};
 
     // scanAddress in the original 32 bit code was a pointer into the color buffer
     // now is an offset that is added to `work.colour.base`
-    uint32_t scanAddress;
-    uint32_t scanAddressTrashed;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t scanAddressTrashed;
+			uint32_t scanAddress;
+#else
+			uint32_t scanAddress;
+			uint32_t scanAddressTrashed;
+#endif
+		};
+		double scanAddress_double;
+	};
 
     // depthAddress in the original 32 bit code was a pointer into the color buffer
     // now is an offset that is added to `work.depth.base`
-    uint32_t depthAddress;
-    uint32_t depthAddressTrashed;
+	union {
+		struct {
+#if BR_ENDIAN_BIG
+			uint32_t depthAddressTrashed;
+			uint32_t depthAddress;
+#else
+			uint32_t depthAddress;
+			uint32_t depthAddressTrashed;
+#endif
+		};
+		double depthAddress_double;
+	};
 
     // qwords end here
     union {
@@ -106,58 +269,250 @@ struct ALIGN(8) workspace_t {
     uint32_t     colour;
     uint32_t     colourExtension;
     uint32_t     shadeTable;
-    uint32_t     scratch0;
-    uint32_t     scratch1;
-    uint32_t     scratch2;
-    uint32_t     scratch3;
-    uint32_t     scratch4;
-    uint32_t     scratch5;
-    uint32_t     scratch6;
-    uint32_t     scratch7;
-    uint32_t     scratch8;
-    uint32_t     scratch9;
-    uint32_t     scratch10;
-    uint32_t     scratch11;
-    uint32_t     scratch12;
-    uint32_t     scratch13;
-    uint32_t     scratch14;
-    uint32_t     scratch15;
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t scratch1;
+            uint32_t scratch0;
+#else
+            uint32_t scratch0;
+            uint32_t scratch1;
+#endif
+        };
+        double scratch0_double;
+    };
+	union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t scratch3;
+            uint32_t scratch2;
+#else
+			uint32_t scratch2;
+			uint32_t scratch3;
+#endif
+		};
+		double scratch2_double;
+	};
+
+	union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t scratch5;
+            uint32_t scratch4;
+#else
+			uint32_t scratch4;
+			uint32_t scratch5;
+#endif
+        };
+		double scratch4_double;
+    };
+	union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t scratch7;
+			uint32_t scratch6;
+#else
+			uint32_t scratch6;
+			uint32_t scratch7;
+#endif
+        };
+        double scratch6_double;
+    };
+	union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t scratch9;
+            uint32_t scratch8;
+#else
+            uint32_t scratch8;
+            uint32_t scratch9;
+#endif
+        };
+        double scratch8_double;
+    };
+	union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t scratch11;
+			uint32_t scratch10;
+#else
+            uint32_t scratch10;
+            uint32_t scratch11;
+#endif
+        };
+        double scratch10_double;
+    };
+	union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t scratch13;
+			uint32_t scratch12;
+#else
+            uint32_t scratch12;
+            uint32_t scratch13;
+#endif
+        };
+        double scratch12_double;
+    };
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t scratch15;
+            uint32_t scratch14;
+#else
+            uint32_t scratch14;
+            uint32_t scratch15;
+#endif
+        };
+        double scratch14_double;
+    };
 };
 
 #define m_y        workspace.t_dy
 #define sort_value workspace.top_vertex
 
 struct ALIGN(8) ArbitraryWidthWorkspace_t {
-    uint32_t su;
-    uint32_t pad0;
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t pad0;
+            uint32_t su;
+#else
+            uint32_t su;
+            uint32_t pad0;
+#endif
+        };
+        double su_double;
+    };
 
-    uint32_t dux;
-    uint32_t pad1;
 
-    uint32_t duy1;
-    uint32_t pad2;
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t pad1;
+            uint32_t dux;
+#else
+            uint32_t dux;
+            uint32_t pad1;
+#endif
+        };
+        double dux_double;
+    };
 
-    uint32_t duy0;
-    uint32_t pad3;
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t pad2;
+            uint32_t duy1;
+#else
+            uint32_t duy1;
+            uint32_t pad2;
+#endif
+        };
+        double duy1_double;
+    };
+
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t pad3;
+            uint32_t duy0;
+#else
+            uint32_t duy0;
+            uint32_t pad3;
+#endif
+        };
+        double duy0_double;
+    };
 
     // originally a pointer into work.texture.base
     // now only an offset
-    uint32_t sv;
-    uint32_t pad4;
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t pad4;
+            uint32_t sv;
+#else
+            uint32_t sv;
+            uint32_t pad4;
+#endif
+        };
+        double sv_double;
+    };
 
-    uint32_t dvy1;
-    uint32_t pad5;
-    uint32_t dvy1c;
-    uint32_t pad6;
-    uint32_t dvy0;
-    uint32_t pad7;
-    uint32_t dvy0c;
-    uint32_t pad10;  // jeffh: added to keep alignment
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t pad5;
+            uint32_t dvy1;
+#else
+            uint32_t dvy1;
+            uint32_t pad5;
+#endif
+        };
+        double dvy1_double;
+    };
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t pad6;
+            uint32_t dvy1c;
+#else
+            uint32_t dvy1c;
+            uint32_t pad6;
+#endif
+        };
+        double dvy1c_double;
+    };
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t pad7;
+            uint32_t dvy0;
+#else
+            uint32_t dvy0;
+            uint32_t pad7;
+#endif
+        };
+        double dvy0_double;
+    };
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t pad10; // jeffh: added to keep alignment
+            uint32_t dvy0c;
+#else
+            uint32_t dvy0c;
+            uint32_t pad10; // jeffh: added to keep alignment
+#endif
+        };
+        double dvy0c_double;
+    };
 
-    uint32_t dvxc;
-    uint32_t pad8;
-    uint32_t dvx;
-    uint32_t pad9;
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t pad8;
+            uint32_t dvxc;
+#else
+            uint32_t dvxc;
+            uint32_t pad8;
+#endif
+        };
+        double dvxc_double;
+    };
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            uint32_t pad9;
+            uint32_t dvx;
+#else
+            uint32_t dvx;
+            uint32_t pad9;
+#endif
+        };
+        double dvx_double;
+    };
 
     uint32_t svf;
     uint32_t dvxf;

--- a/drivers/pentprim/pfpsetup.c
+++ b/drivers/pentprim/pfpsetup.c
@@ -17,6 +17,7 @@
 
 #define work_bot_count			workspace.bottomCount
 #define work_bot_i				workspace.x2
+#define work_bot_i_double		workspace.x2_double
 #define work_bot_d_i			workspace.d_x2
 
 #define work_pz_current			workspace.s_z
@@ -416,11 +417,11 @@ count_cont:
     // 		 FXCH		st(2)						;	g1+C	gm+C	g2+C	x_1		x_m		x_2+C
     FXCH(2);
     // 		fstp real8 ptr [workspace].x1			;	gm+C	g2+C	x_1		x_m		x_2+C
-    FSTP64(&workspace.x1);
+    FSTP64(&workspace.x1_double);
     // 		fstp real8 ptr [workspace].xm			;	g2+C	x_1		x_m		x_2+C
-    FSTP64(&workspace.xm);
+    FSTP64(&workspace.xm_double);
     // 		fstp real8 ptr [workspace].x2			;	x_1		x_m		x_2+C
-    FSTP64(&workspace.x2);
+    FSTP64(&workspace.x2_double);
     // 		fadd	fconv_d16_12[esi*8]				;	x_1+C	x_m		x_2+C
     FADD64(fconv_d16_12[esi.v]);
     // 		FXCH		st(1)						;	x_m		x_1+C	x_2+C
@@ -439,11 +440,11 @@ count_cont:
     // 		mov		ebx,[workspace.v0]				; Start preparing for parmeter setup
     ebx.ptr_v = workspace.v0;
     // 		fstp real8 ptr [workspace].xm			;	x_1+C	x_2+C
-    FSTP64(&workspace.xm);
+    FSTP64(&workspace.xm_double);
     // 		fstp real8 ptr [workspace].x1			;	x_2+C
-    FSTP64(&workspace.x1);
+    FSTP64(&workspace.x1_double);
 	//      fstp	real8 ptr work_bot_i		;
-	FSTP64(&work_bot_i);
+	FSTP64(&work_bot_i_double);
 
     // mov		work_main_d_i,edx
 	work_main_d_i = edx.v;
@@ -1181,7 +1182,7 @@ exact:
     // fxch	st(6)						;	ustrt+C	dv1		dv2		v'q'0	udy_0'	dv1		udx+C
     FXCH(6);
     // fstp	real8 ptr work.pu.currentpix ;	dv1		dv2		v'q'0	udy_0'	dv1		udx+C
-    FSTP64(&work.pu.currentpix);
+    FSTP64(&work.pu.currentpix_double);
     // fld		st(1)						;	dv2		dv1		dv2		v'q'0	udy_0'	dv1		udx+C
     FLD_ST(1);
     // fxch	st(4)						;	udy_0'	dv1		dv2		v'q'0	dv2		dv1		udx+C
@@ -1191,13 +1192,13 @@ exact:
     // fxch	st(6)						;	udx+C	dv1		dv2		v'q'0	dv2		dv1		udy_0+C
     FXCH(6);
     // fstp	real8 ptr work.pu.grad_x	;	dv1		dv2		v'q'0	dv2		dv1		udy_0+C
-    FSTP64(&work.pu.grad_x);
+    FSTP64(&work.pu.grad_x_double);
     // fmul	workspace_dy2_a				;	dv1*b	dv2		v'q'0	dv2		dv1		udy_0+C
     FMUL(workspace_dy2_a);
     // fxch	st(5)						;	udy_0+C	dv2		v'q'0	dv2		dv1		dv1*b
     FXCH(5);
     // fstp	real8 ptr work.pu.d_carry	;	dv2		v'q'0	dv2		dv1		dv1*b
-    FSTP64(&work.pu.d_carry);
+    FSTP64(&work.pu.d_carry_double);
     // fmul	workspace_dy1_a				;	dv2*a	v'q'0	dv2		dv1		dv1*b
     FMUL(workspace_dy1_a);
     // fxch	st(3)						;	dv1		v'q'0	dv2		dv2*a	dv1*b
@@ -1277,11 +1278,11 @@ exact:
     // fxch	st(2)						;	vdx+C	vstrt+C	vdy_0+C
     FXCH(2);
     // fstp	real8 ptr work.pv.grad_x	;	vstrt+C	vdy_0+C
-    FSTP64(&work.pv.grad_x);
+    FSTP64(&work.pv.grad_x_double);
     // fstp	real8 ptr work.pv.currentpix ;	vdy_0+C
-    FSTP64(&work.pv.currentpix);
+    FSTP64(&work.pv.currentpix_double);
     // fstp	real8 ptr work.pv.d_carry	;
-    FSTP64(&work.pv.d_carry);
+    FSTP64(&work.pv.d_carry_double);
 
     // mov		eax,work.pv.currentpix
     eax.v = work.pv.currentpix;
@@ -1408,17 +1409,17 @@ exact:
     // fxch	st(2)						;	C+qdy_1	C+qdy_0	C+qstrt	C+qdx
     FXCH(2);
     // fstp	real8 ptr work.pq.d_carry	;	C+qdy_0	C+qstrt	C+qdx
-    FSTP64(&work.pq.d_carry);
+    FSTP64(&work.pq.d_carry_double);
     // fstp	real8 ptr work.pq.grad_x	;	C+qstrt	C+qdx
-    FSTP64(&work.pq.grad_x);
+    FSTP64(&work.pq.grad_x_double);
     // fstp	real8 ptr work.pq.currentpix ;	C+qdx
-    FSTP64(&work.pq.currentpix);
+    FSTP64(&work.pq.currentpix_double);
     // mov		eax,work.pq.grad_x
     eax.v = work.pq.grad_x;
     // mov		ebx,work.pq.currentpix
     ebx.v = work.pq.currentpix;
     // fstp	real8 ptr work.pq.grad_x	;
-    FSTP64(&work.pq.grad_x);
+    FSTP64(&work.pq.grad_x_double);
     // mov		work.pq.d_nocarry,eax
     work.pq.d_nocarry = eax.v;
     // mov		work.pq.current,ebx
@@ -1430,7 +1431,7 @@ void TriangleSetup_ZPT(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
         return;
     }
 	//SETUP_FLOAT_PARAM C_SZ,pz,fp_conv_d16,1
-	SETUP_FLOAT_PARAM(C_SZ,"_z",&workspace.s_z,&workspace.d_z_x,fp_conv_d16,1);
+	SETUP_FLOAT_PARAM(C_SZ,"_z",&workspace.s_z_double,&workspace.d_z_x_double,fp_conv_d16,1);
 	if (SETUP_FLOAT_CHECK_PERSPECTIVE_CHEAT() == CHEAT_YES) {
 		// mov	esi,work.tsl.direction
 		// mov	workspace.flip,esi
@@ -1438,8 +1439,8 @@ void TriangleSetup_ZPT(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
 
 		// SETUP_FLOAT_PARAM C_U,pu,fp_conv_d16
 		// SETUP_FLOAT_PARAM C_V,pv,fp_conv_d16
-		SETUP_FLOAT_PARAM(C_U,"_u",&workspace.s_u,&workspace.d_u_x,fp_conv_d16, 0);
-		SETUP_FLOAT_PARAM(C_V,"_v",&workspace.s_v,&workspace.d_v_x,fp_conv_d16, 0);
+		SETUP_FLOAT_PARAM(C_U,"_u",&workspace.s_u_double,&workspace.d_u_x_double,fp_conv_d16, 0);
+		SETUP_FLOAT_PARAM(C_V,"_v",&workspace.s_v_double,&workspace.d_v_x_double,fp_conv_d16, 0);
 		//stc
 		x86_state.cf = 1;
 	} else {
@@ -1454,7 +1455,7 @@ void TriangleSetup_ZPT_NOCHEAT(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
         return;
     }
 	//SETUP_FLOAT_PARAM C_SZ,pz,fp_conv_d16,1
-	SETUP_FLOAT_PARAM(C_SZ,"_z",&workspace.s_z,&workspace.d_z_x,fp_conv_d16,1);
+	SETUP_FLOAT_PARAM(C_SZ,"_z",&workspace.s_z_double,&workspace.d_z_x_double,fp_conv_d16,1);
     // mov		esi,top_vertex
     esi.ptr_v = top_mid_bot_vertices[0];
     // mov		edi,mid_vertex
@@ -1469,9 +1470,9 @@ void TriangleSetup_ZPTI(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
         return;
     }
 	//SETUP_FLOAT_PARAM C_SZ,pz,fp_conv_d16,1
-	SETUP_FLOAT_PARAM(C_SZ,"_z",&workspace.s_z,&workspace.d_z_x,fp_conv_d16,1);
+	SETUP_FLOAT_PARAM(C_SZ,"_z",&workspace.s_z_double,&workspace.d_z_x_double,fp_conv_d16,1);
     // SETUP_FLOAT_PARAM C_I,pi,fp_conv_d16
-    SETUP_FLOAT_PARAM(C_I,"_i",&workspace.s_i,&workspace.d_i_x,fp_conv_d16, 0);
+    SETUP_FLOAT_PARAM(C_I,"_i",&workspace.s_i_double,&workspace.d_i_x_double,fp_conv_d16, 0);
 	if (SETUP_FLOAT_CHECK_PERSPECTIVE_CHEAT() == CHEAT_YES) {
 		// mov	esi,work.tsl.direction
 		// mov	workspace.flip,esi
@@ -1479,8 +1480,8 @@ void TriangleSetup_ZPTI(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
 
 		// SETUP_FLOAT_PARAM C_U,pu,fp_conv_d16
 		// SETUP_FLOAT_PARAM C_V,pv,fp_conv_d16
-		SETUP_FLOAT_PARAM(C_U,"_u",&workspace.s_u,&workspace.d_u_x,fp_conv_d16, 0);
-		SETUP_FLOAT_PARAM(C_V,"_v",&workspace.s_v,&workspace.d_v_x,fp_conv_d16, 0);
+		SETUP_FLOAT_PARAM(C_U,"_u",&workspace.s_u_double,&workspace.d_u_x_double,fp_conv_d16, 0);
+		SETUP_FLOAT_PARAM(C_V,"_v",&workspace.s_v_double,&workspace.d_v_x_double,fp_conv_d16, 0);
 		//stc
 		x86_state.cf = 1;
 	} else {
@@ -1495,9 +1496,9 @@ void TriangleSetup_ZPTI_NOCHEAT(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) 
         return;
     }
 	//SETUP_FLOAT_PARAM C_SZ,pz,fp_conv_d16,1
-	SETUP_FLOAT_PARAM(C_SZ,"_z",&workspace.s_z,&workspace.d_z_x,fp_conv_d16,1);
+	SETUP_FLOAT_PARAM(C_SZ,"_z",&workspace.s_z_double,&workspace.d_z_x_double,fp_conv_d16,1);
     // SETUP_FLOAT_PARAM C_I,pi,fp_conv_d16
-    SETUP_FLOAT_PARAM(C_I,"_i",&workspace.s_i,&workspace.d_i_x,fp_conv_d16, 0);
+    SETUP_FLOAT_PARAM(C_I,"_i",&workspace.s_i_double,&workspace.d_i_x_double,fp_conv_d16, 0);
     // mov		esi,top_vertex
     esi.ptr_v = top_mid_bot_vertices[0];
     // mov		edi,mid_vertex

--- a/drivers/pentprim/work.h
+++ b/drivers/pentprim/work.h
@@ -30,12 +30,42 @@ struct scan_edge {
  * Scan convertion details for one parameter
  */
 struct scan_parameter {
-	br_fixed_ls	currentpix;	/* Parameter (16.16) value at pixel				*/
-	br_fixed_ls	current;	/* Parameter (16.16) value at start of scanline	*/
-	br_fixed_ls	d_carry;	/* Increment per scanline if carry from bit 15	*/
-	br_fixed_ls	d_nocarry;	/*   ""              ""      no carry   ""    	*/
-	br_fixed_ls	grad_x;		/* Gradient of parameter along X axis			*/
-	br_fixed_ls	grad_y;		/* Gradient of parameter along Y axis			*/
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            br_fixed_ls current;    /* Parameter (16.16) value at start of scanline	*/
+            br_fixed_ls currentpix; /* Parameter (16.16) value at pixel				*/
+#else
+            br_fixed_ls currentpix; /* Parameter (16.16) value at pixel				*/
+            br_fixed_ls current;    /* Parameter (16.16) value at start of scanline	*/
+#endif
+        };
+        double currentpix_double;
+    };
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            br_fixed_ls d_nocarry; /*   ""              ""      no carry   ""    	*/
+            br_fixed_ls d_carry;   /* Increment per scanline if carry from bit 15	*/
+#else
+            br_fixed_ls d_carry;   /* Increment per scanline if carry from bit 15	*/
+            br_fixed_ls d_nocarry; /*   ""              ""      no carry   ""    	*/
+#endif
+        };
+        double d_carry_double;
+    };
+    union {
+        struct {
+#if BR_ENDIAN_BIG
+            br_fixed_ls grad_y; /* Gradient of parameter along Y axis			*/
+            br_fixed_ls grad_x; /* Gradient of parameter along X axis			*/
+#else
+            br_fixed_ls grad_x; /* Gradient of parameter along X axis			*/
+            br_fixed_ls grad_y; /* Gradient of parameter along Y axis			*/
+#endif
+        };
+        double grad_x_double;
+    };
 };
 
 /*

--- a/drivers/pentprim/zb8.c
+++ b/drivers/pentprim/zb8.c
@@ -219,9 +219,9 @@ void BR_ASM_CALL TriangleRender_Z_I8_D16(brp_block *block, ...) {
     // faddp st(2),st					;	ca			da
     FADDP_ST(2, 0);
     // fstp qword ptr workspace.scanAddress
-    FSTP64(&workspace.scanAddress);
+    FSTP64(&workspace.scanAddress_double);
     // fstp qword ptr workspace.depthAddress
-    FSTP64(&workspace.depthAddress);
+    FSTP64(&workspace.depthAddress_double);
     // mov eax,workspace.xm
     eax.v = workspace.xm;
     // shl eax,16

--- a/drivers/pentprim/zb8awtm.c
+++ b/drivers/pentprim/zb8awtm.c
@@ -386,7 +386,7 @@ drawPixel:
     // 	mov bx,[ebp+2*ecx]
     ebx.short_low = ((uint16_t *)work.depth.base)[ebp.v / 2 + ecx.int_val];
     // 	mov dx,word ptr workspace.c_z+2
-    edx.short_low = ((uint16_t *)&workspace.c_z)[1];
+    edx.short_low = workspace.c_z >> 16;
 
     // 	cmp dx,bx
     // 	ja noPlot
@@ -620,7 +620,7 @@ drawPixel:
     // 	mov bx,[ebp+2*ecx]
     ebx.short_low = ((uint16_t *)work.depth.base)[ebp.v / 2 + ecx.int_val];
     // 	mov dx,word ptr workspace.c_z+2
-    edx.short_low = ((uint16_t *)&workspace.c_z)[1];
+    edx.short_low = workspace.c_z >> 16;
 
     // 	cmp dx,bx
     // 	ja noPlot
@@ -865,9 +865,9 @@ void TriangleRender_ZT_I8_D16(brp_block *block, ...)
     // 	faddp st(2),st					;	ca			da
     FADDP_ST(2, 0);
     // 	fstp qword ptr workspace.scanAddress
-    FSTP64(&workspace.scanAddress);
+    FSTP64(&workspace.scanAddress_double);
     // 	fstp qword ptr workspace.depthAddress
-    FSTP64(&workspace.depthAddress);
+    FSTP64(&workspace.depthAddress_double);
 
     // 	mov eax,work.texture.base
     eax.v = WORK_TEXTURE_BASE;
@@ -983,9 +983,9 @@ void BR_ASM_CALL TriangleRender_ZTI_I8_D16(brp_block *block, ...) {
     // 	faddp st(2),st					;	ca			da
     FADDP_ST(2, 0);
     // 	fstp qword ptr workspace.scanAddress
-    FSTP64(&workspace.scanAddress);
+    FSTP64(&workspace.scanAddress_double);
     // 	fstp qword ptr workspace.depthAddress
-    FSTP64(&workspace.depthAddress);
+    FSTP64(&workspace.depthAddress_double);
 
     // 	mov eax,work.texture.base
     eax.v = WORK_TEXTURE_BASE;
@@ -1133,9 +1133,9 @@ void BR_ASM_CALL TriangleRender_ZTB_I8_D16(brp_block *block, ...) {
     // 	faddp st(2),st					;	ca			da
     FADDP_ST(2, 0);
     // 	fstp qword ptr workspace.scanAddress
-    FSTP64(&workspace.scanAddress);
+    FSTP64(&workspace.scanAddress_double);
     // 	fstp qword ptr workspace.depthAddress
-    FSTP64(&workspace.depthAddress);
+    FSTP64(&workspace.depthAddress_double);
 
     // 	mov eax,work.texture.base
     eax.v = WORK_TEXTURE_BASE;

--- a/drivers/pentprim/zb8p2lit.c
+++ b/drivers/pentprim/zb8p2lit.c
@@ -337,9 +337,9 @@ void BR_ASM_CALL TriangleRender_ZTI_I8_D16_POW2(brp_block *block, int pow2, int 
 	workspace.xm_f = eax.v;
 
 // 	fstp qword ptr workspace.scanAddress
-	FSTP64(&workspace.scanAddress);
+	FSTP64(&workspace.scanAddress_double);
 // 	fstp qword ptr workspace.depthAddress
-	FSTP64(&workspace.depthAddress);
+	FSTP64(&workspace.depthAddress_double);
 
 // 	mov workspace.d_xm_f,ebx
 	workspace.d_xm_f = ebx.v;

--- a/drivers/pentprim/zb8p2ulb.c
+++ b/drivers/pentprim/zb8p2ulb.c
@@ -346,9 +346,9 @@ void BR_ASM_CALL TriangleRender_ZTB_I8_D16_POW2(brp_block *block, int pow2, int 
 	workspace.xm_f = eax.v;
 
 // 	fstp qword ptr workspace.scanAddress
-	FSTP64(&workspace.scanAddress);
+	FSTP64(&workspace.scanAddress_double);
 // 	fstp qword ptr workspace.depthAddress
-	FSTP64(&workspace.depthAddress);
+	FSTP64(&workspace.depthAddress_double);
 
 // 	mov workspace.d_xm_f,ebx
 	workspace.d_xm_f = ebx.v;

--- a/drivers/pentprim/zb8p2unl.c
+++ b/drivers/pentprim/zb8p2unl.c
@@ -342,9 +342,9 @@ void BR_ASM_CALL TriangleRender_ZT_I8_D16_POW2(brp_block *block, int pow2, int s
 	workspace.xm_f = eax.v;
 
 // 	fstp qword ptr workspace.scanAddress
-	FSTP64(&workspace.scanAddress);
+	FSTP64(&workspace.scanAddress_double);
 // 	fstp qword ptr workspace.depthAddress
-	FSTP64(&workspace.depthAddress);
+	FSTP64(&workspace.depthAddress_double);
 
 // 	mov workspace.d_xm_f,ebx
 	workspace.d_xm_f = ebx.v;


### PR DESCRIPTION
This is a big one, but most of the ugliness is in fpwork.h and work.h as I had to add unions everywhere. I tested these changes on Win64 too to make sure I didn't break anything.