### PR TITLE
Remove varargs usage from softrend/pentprim

### DIFF
--- a/drivers/pentprim/drv_ip.h
+++ b/drivers/pentprim/drv_ip.h
@@ -57,7 +57,7 @@ void BR_ASM_CALL TriangleRender_Z_I8_D16(brp_block *block, brp_vertex *v0, brp_v
 void BR_ASM_CALL TriangleRender_Z_I8_D16_ShadeTable(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2);
 void BR_ASM_CALL TriangleRenderPIZ2I(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2);
 void BR_ASM_CALL TriangleRender_ZI_I8_D16_ShadeTable(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2);
-void BR_ASM_CALL TriangleRender_ZI_I8_D16(brp_block *block, ...);
+void BR_ASM_CALL TriangleRender_ZI_I8_D16(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2);
 void BR_ASM_CALL TriangleRender_ZIF_I8_D16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2);
 void BR_ASM_CALL TriangleRender_ZIF_I8_D16_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2);
 
@@ -272,9 +272,9 @@ void BR_ASM_CALL TriangleRender_ZPTFB_I8_D16_1024(brp_block *block, brp_vertex *
  * l_piz.c
  */
 
-void BR_ASM_CALL LineRenderPIZ2I(brp_block *block, ...);
-void BR_ASM_CALL LineRenderPIZ2T(brp_block *block, ...);
-void BR_ASM_CALL LineRenderPIZ2TI(brp_block *block, ...);
+void BR_ASM_CALL LineRenderPIZ2I(brp_block *block, brp_vertex *v0, brp_vertex *v1);
+void BR_ASM_CALL LineRenderPIZ2T(brp_block *block, brp_vertex *v0, brp_vertex *v1);
+void BR_ASM_CALL LineRenderPIZ2TI(brp_block *block, brp_vertex *v0, brp_vertex *v1);
 
 void BR_ASM_CALL LineRenderPFZ2I(brp_block *block, brp_vertex *v0,brp_vertex *v1);
 void BR_ASM_CALL LineRenderPFZ2I555(brp_block *block, brp_vertex *v0,brp_vertex *v1);

--- a/drivers/pentprim/fti8_piz.c
+++ b/drivers/pentprim/fti8_piz.c
@@ -250,18 +250,7 @@ no_pixels:
 
 
 
-void BR_ASM_CALL TriangleRender_ZI_I8_D16(brp_block *block, ...) {
-
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-
-    va_list     va;
-    va_start(va, block);
-    v0 = va_arg(va, brp_vertex *);
-    v1 = va_arg(va, brp_vertex *);
-    v2 = va_arg(va, brp_vertex *);
-	va_end(va);
+void BR_ASM_CALL TriangleRender_ZI_I8_D16(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
 
     // ; Get pointers to vertex structures
 	// ;

--- a/drivers/pentprim/fti8pizp.c
+++ b/drivers/pentprim/fti8pizp.c
@@ -34,9 +34,9 @@
 #define ENABLE_PERSPECTIVE_CHEAT_FOR_BLEND 0
 
 // non-perspective if following cheat mode
-void BR_ASM_CALL TriangleRender_ZT_I8_D16_POW2(brp_block *block, int pow2, int skip_setup, va_list va);
-void BR_ASM_CALL TriangleRender_ZTB_I8_D16_POW2(brp_block *block, int pow2, int skip_setup, va_list va);
-void BR_ASM_CALL TriangleRender_ZTI_I8_D16_POW2(brp_block *block, int pow2, int skip_setup, va_list va);
+void BR_ASM_CALL TriangleRender_ZT_I8_D16_POW2(brp_block *block, int pow2, int skip_setup, brp_vertex* v0, brp_vertex* v1, brp_vertex* v2);
+void BR_ASM_CALL TriangleRender_ZTB_I8_D16_POW2(brp_block *block, int pow2, int skip_setup, brp_vertex* v0, brp_vertex* v1, brp_vertex* v2);
+void BR_ASM_CALL TriangleRender_ZTI_I8_D16_POW2(brp_block *block, int pow2, int skip_setup, brp_vertex* v0, brp_vertex* v1, brp_vertex* v2);
 
 typedef struct trapezium_render_size_params {
     int pre;
@@ -1845,37 +1845,24 @@ carry:
     }
 }
 
-void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_32(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_32(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_32_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_32_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPT_I8_D16_32(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPT_I8_D16_32(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_64(brp_block *block, ...) {
-    va_list     va;
-    va_start(va, block);
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-
-	v0 = va_arg(va, brp_vertex *);
-    v1 = va_arg(va, brp_vertex *);
-    v2 = va_arg(va, brp_vertex *);
-    va_end(va);
+void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_64(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
 
     TriangleSetup_ZPTI(v0, v1, v2);
     // jc TriangleRasterise_ZTI_I8_D16_64
     if (x86_state.cf) {
-        va_list l;
-        va_start(l, block);
-        TriangleRender_ZTI_I8_D16_POW2(block, 6, 1, l);
-        va_end(l);
+        TriangleRender_ZTI_I8_D16_POW2(block, 6, 1, v0, v1, v2);
         return;
     }
 
@@ -2023,30 +2010,17 @@ reversed:
     TrapeziumRender_ZPTI_I8_D16(DIR_B, eTrapezium_render_size_64, eFog_no, eBlend_no);
 }
 
-void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_64_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_64_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
 
-void BR_ASM_CALL TriangleRender_ZPT_I8_D16_64(brp_block *block, ...) {
-    va_list     va;
-    va_start(va, block);
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-
-	v0 = va_arg(va, brp_vertex *);
-    v1 = va_arg(va, brp_vertex *);
-    v2 = va_arg(va, brp_vertex *);
-    va_end(va);
+void BR_ASM_CALL TriangleRender_ZPT_I8_D16_64(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
 
     TriangleSetup_ZPT(v0, v1, v2);
     // jc TriangleRasterise_ZT_I8_D16_64
     if (x86_state.cf) {
-        va_list l;
-        va_start(l, block);
-        TriangleRender_ZT_I8_D16_POW2(block, 6, 1, l);
-        va_end(l);
+        TriangleRender_ZT_I8_D16_POW2(block, 6, 1, v0, v1, v2);
         return;
     }
 
@@ -2177,40 +2151,27 @@ reversed:
 
 }
 
-void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_128(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_128(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
 
-void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_128_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_128_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
 
-void BR_ASM_CALL TriangleRender_ZPT_I8_D16_128(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPT_I8_D16_128(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
 
-void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_256(brp_block *block, ...) {
-    va_list     va;
-    va_start(va, block);
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-
-	v0 = va_arg(va, brp_vertex *);
-    v1 = va_arg(va, brp_vertex *);
-    v2 = va_arg(va, brp_vertex *);
-    va_end(va);
+void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_256(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
 
     TriangleSetup_ZPTI(v0, v1, v2);
     // jc TriangleRasterise_ZTI_I8_D16_256
     if (x86_state.cf) {
-        va_list l;
-        va_start(l, block);
-        TriangleRender_ZTI_I8_D16_POW2(block, 8, 1, l);
-        va_end(l);
+        TriangleRender_ZTI_I8_D16_POW2(block, 8, 1, v0, v1, v2);
         return;
     }
 
@@ -2344,30 +2305,16 @@ reversed:
     TrapeziumRender_ZPTI_I8_D16(DIR_B, eTrapezium_render_size_256, eFog_no, eBlend_no);
 }
 
-void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_256_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_256_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
 
-void BR_ASM_CALL TriangleRender_ZPT_I8_D16_256(brp_block *block, ...) {
-    va_list     va;
-    va_start(va, block);
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-
-	v0 = va_arg(va, brp_vertex *);
-    v1 = va_arg(va, brp_vertex *);
-    v2 = va_arg(va, brp_vertex *);
-    va_end(va);
-
+void BR_ASM_CALL TriangleRender_ZPT_I8_D16_256(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     TriangleSetup_ZPT(v0, v1, v2);
     // jc TriangleRasterise_ZT_I8_D16_256
     if (x86_state.cf) {
-        va_list l;
-        va_start(l, block);
-        TriangleRender_ZT_I8_D16_POW2(block, 8, 1, l);
-        va_end(l);
+        TriangleRender_ZT_I8_D16_POW2(block, 8, 1, v0, v1, v2);
         return;
     }
 
@@ -2493,118 +2440,104 @@ reversed:
     TrapeziumRender_ZPT_I8_D16(DIR_B, eTrapezium_render_size_256, eFog_no, eBlend_no);
 }
 
-void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_1024(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_1024_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_1024_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPT_I8_D16_1024(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPT_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_32(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_32(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_32_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_32_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTF_I8_D16_32(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTF_I8_D16_32(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_64(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_64(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_64_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_64_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTF_I8_D16_64(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTF_I8_D16_64(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_128(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_128(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_128_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_128_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTF_I8_D16_128(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTF_I8_D16_128(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_256(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_256(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_256_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_256_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTF_I8_D16_256(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTF_I8_D16_256(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_1024(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_1024_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIF_I8_D16_1024_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTF_I8_D16_1024(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTF_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_32(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_32(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_32_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_32_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTB_I8_D16_32(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTB_I8_D16_32(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_64(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_64(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_64_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_64_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTB_I8_D16_64(brp_block *block, ...) {
-    va_list     va;
-    va_start(va, block);
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-
-	v0 = va_arg(va, brp_vertex *);
-    v1 = va_arg(va, brp_vertex *);
-    v2 = va_arg(va, brp_vertex *);
-    va_end(va);
-
+void BR_ASM_CALL TriangleRender_ZPTB_I8_D16_64(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
 #if ENABLE_PERSPECTIVE_CHEAT_FOR_BLEND==1
     TriangleSetup_ZPT(v0, v1, v2);
     // jc TriangleRasterise_ZTB_I8_D16_64
     if (x86_state.cf) {
-        va_list l;
-        va_start(l, block);
-        TriangleRender_ZTB_I8_D16_POW2(block, 6, 1, l);
-        va_end(l);
+        TriangleRender_ZTB_I8_D16_POW2(block, 6, 1, v0, v1, v2);
         return;
     }
 #else
@@ -2738,46 +2671,32 @@ reversed:
 
 }
 
-void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_128(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_128(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_128_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_128_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTB_I8_D16_128(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTB_I8_D16_128(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_256(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_256(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_256_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_256_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTB_I8_D16_256(brp_block *block, ...) {
-    va_list     va;
-    va_start(va, block);
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-
-	v0 = va_arg(va, brp_vertex *);
-    v1 = va_arg(va, brp_vertex *);
-    v2 = va_arg(va, brp_vertex *);
-    va_end(va);
-
+void BR_ASM_CALL TriangleRender_ZPTB_I8_D16_256(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
 #if ENABLE_PERSPECTIVE_CHEAT_FOR_BLEND==1
     TriangleSetup_ZPT(v0, v1, v2);
     // jc TriangleRasterise_ZTB_I8_D16_256
     if (x86_state.cf) {
-        va_list l;
-        va_start(l, block);
-        TriangleRender_ZTB_I8_D16_POW2(block, 8, 1, l);
-        va_end(l);
+        TriangleRender_ZTB_I8_D16_POW2(block, 8, 1, v0, v1, v2);
         return;
     }
 #else
@@ -2906,75 +2825,75 @@ reversed:
     TrapeziumRender_ZPT_I8_D16(DIR_B, eTrapezium_render_size_256, eFog_no, eBlend_yes);
 }
 
-void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_1024(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_1024_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIB_I8_D16_1024_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTB_I8_D16_1024(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTB_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_32(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_32(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_32_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_32_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTFB_I8_D16_32(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTFB_I8_D16_32(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_64(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_64(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_64_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_64_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTFB_I8_D16_64(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTFB_I8_D16_64(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_128(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_128(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_128_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_128_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTFB_I8_D16_128(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTFB_I8_D16_128(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_256(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_256(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_256_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_256_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTFB_I8_D16_256(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTFB_I8_D16_256(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_1024(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_1024_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTIFB_I8_D16_1024_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZPTFB_I8_D16_1024(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZPTFB_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }

--- a/drivers/pentprim/l_piz.c
+++ b/drivers/pentprim/l_piz.c
@@ -29,7 +29,7 @@ static char rscid[] = "$Id: l_piz.c 1.1 1997/12/10 16:47:12 jon Exp $";
 /*
  * Line drawer - Proper Bresenham algorithm
  */
-void BR_ASM_CALL LineRenderPIZ2I(struct brp_block *block, ...)
+void BR_ASM_CALL LineRenderPIZ2I(struct brp_block *block, brp_vertex *v0, brp_vertex *v1)
 {
 	br_fixed_ls dx,dy;
 	br_fixed_ls pm,dm,pz,dz,pi,di,x0,x1,y0,y1;
@@ -38,15 +38,6 @@ void BR_ASM_CALL LineRenderPIZ2I(struct brp_block *block, ...)
 	int X0,Y0,X1,Y1;
 	char *ptr,*zptr;
 	int dptr,dzptr;
-
-	va_list va;
-	brp_vertex *v0;
-    brp_vertex *v1;
-
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-	va_end(va);
 
 	di = 0;
 	dz = 0;
@@ -210,7 +201,7 @@ void BR_ASM_CALL LineRenderPIZ2I(struct brp_block *block, ...)
 /*
  * Arbitrary size lit textured line drawer
  */
-void BR_ASM_CALL LineRenderPIZ2TI(struct brp_block *block, ...)
+void BR_ASM_CALL LineRenderPIZ2TI(struct brp_block *block, brp_vertex *v0, brp_vertex *v1)
 {
 	br_fixed_ls dx,dy;
 	br_fixed_ls pm,dm,pz,dz,pi,di,x0,x1,y0,y1;
@@ -221,15 +212,6 @@ void BR_ASM_CALL LineRenderPIZ2TI(struct brp_block *block, ...)
 	char *ptr,*zptr;
 	int dptr,dzptr;
 	int width,height,stride;
-
-	va_list va;
-	brp_vertex *v0;
-    brp_vertex *v1;
-
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-	va_end(va);
 
 	width = work.texture.width_p;
 	height = work.texture.height;
@@ -449,7 +431,7 @@ void BR_ASM_CALL LineRenderPIZ2TI(struct brp_block *block, ...)
 /*
  * Arbitrary size textured line drawer
  */
-void BR_ASM_CALL LineRenderPIZ2T(struct brp_block *block, ...)
+void BR_ASM_CALL LineRenderPIZ2T(struct brp_block *block, brp_vertex *v0, brp_vertex *v1)
 {
 	br_fixed_ls dx,dy;
 	br_fixed_ls pm,dm,pz,dz,x0,x1,y0,y1;
@@ -460,15 +442,6 @@ void BR_ASM_CALL LineRenderPIZ2T(struct brp_block *block, ...)
 	char *ptr,*zptr;
 	int dptr,dzptr;
 	int width,height,stride;
-
-	va_list va;
-	brp_vertex *v0;
-    brp_vertex *v1;
-
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-	va_end(va);
 
     width = work.texture.width_p;
     height = work.texture.height;

--- a/drivers/pentprim/match.c
+++ b/drivers/pentprim/match.c
@@ -779,7 +779,7 @@ void BR_ASM_CALL RenderAutoloadThunk(brp_block *block, brp_vertex *v0, brp_verte
 	/*
 	 * Hand over to new rendering function
 	 */
-	render_fn(block,v0,v1,v2);
+	render_fn(block,v0,v1,v2,NULL,NULL,NULL,NULL);
 }
 
 /*
@@ -840,7 +840,7 @@ void BR_ASM_CALL GenericAutoloadThunk(brp_block *block, brp_vertex *v0, brp_vert
 	/*
 	 * Hand over to setp function
 	 */
-	pb->p.render(block,v0,v1,v2);
+	pb->p.render(block,v0,v1,v2,NULL,NULL,NULL,NULL);
 }
 
 br_error BR_CMETHOD_DECL(br_primitive_state_soft, rangesQueryF)(

--- a/drivers/pentprim/zb8.c
+++ b/drivers/pentprim/zb8.c
@@ -142,17 +142,7 @@ lineDrawn:
     }
 }
 
-void BR_ASM_CALL TriangleRender_Z_I8_D16(brp_block *block, ...) {
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    va_list     va;
-    va_start(va, block);
-    v0 = va_arg(va, brp_vertex *);
-    v1 = va_arg(va, brp_vertex *);
-    v2 = va_arg(va, brp_vertex *);
-    va_end(va);
-
+void BR_ASM_CALL TriangleRender_Z_I8_D16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     workspace.v0 = v0;
     workspace.v1 = v1;
     workspace.v2 = v2;
@@ -262,7 +252,7 @@ void BR_ASM_CALL TriangleRender_Z_I8_D16(brp_block *block, ...) {
     }
 }
 
-void BR_ASM_CALL TriangleRender_Z_I8_D16_ShadeTable(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_Z_I8_D16_ShadeTable(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }

--- a/drivers/pentprim/zb8awtm.c
+++ b/drivers/pentprim/zb8awtm.c
@@ -801,18 +801,8 @@ returnAddress:
     }
 }
 
-void TriangleRender_ZT_I8_D16(brp_block *block, ...)
+void TriangleRender_ZT_I8_D16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2)
 {
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    va_list     va;
-    va_start(va, block);
-    v0 = va_arg(va, brp_vertex *);
-    v1 = va_arg(va, brp_vertex *);
-    v2 = va_arg(va, brp_vertex *);
-    va_end(va);
-
     workspace.v0 = v0;
     workspace.v1 = v1;
     workspace.v2 = v2;
@@ -920,17 +910,7 @@ void TriangleRender_ZT_I8_D16(brp_block *block, ...)
 }
 
 
-void BR_ASM_CALL TriangleRender_ZTI_I8_D16(brp_block *block, ...) {
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    va_list     va;
-    va_start(va, block);
-    v0 = va_arg(va, brp_vertex *);
-    v1 = va_arg(va, brp_vertex *);
-    v2 = va_arg(va, brp_vertex *);
-    va_end(va);
-
+void BR_ASM_CALL TriangleRender_ZTI_I8_D16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     workspace.v0 = v0;
     workspace.v1 = v1;
     workspace.v2 = v2;
@@ -1037,50 +1017,40 @@ void BR_ASM_CALL TriangleRender_ZTI_I8_D16(brp_block *block, ...) {
     }
 }
 
-void BR_ASM_CALL TriangleRender_ZTI_I8_D16_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTI_I8_D16_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZTIF_I8_D16(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTIF_I8_D16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZTIF_I8_D16_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTIF_I8_D16_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZTIB_I8_D16(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTIB_I8_D16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZTIB_I8_D16_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTIB_I8_D16_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZTIFB_I8_D16(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTIFB_I8_D16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZTIFB_I8_D16_FLAT(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTIFB_I8_D16_FLAT(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
 
-void BR_ASM_CALL TriangleRender_ZTF_I8_D16(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTF_I8_D16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZTB_I8_D16(brp_block *block, ...) {
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    va_list     va;
-    va_start(va, block);
-    v0 = va_arg(va, brp_vertex *);
-    v1 = va_arg(va, brp_vertex *);
-    v2 = va_arg(va, brp_vertex *);
-    va_end(va);
-
+void BR_ASM_CALL TriangleRender_ZTB_I8_D16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     workspace.v0 = v0;
     workspace.v1 = v1;
     workspace.v2 = v2;
@@ -1186,7 +1156,7 @@ void BR_ASM_CALL TriangleRender_ZTB_I8_D16(brp_block *block, ...) {
             BrFailure("Invalid enum value");
     }
 }
-void BR_ASM_CALL TriangleRender_ZTFB_I8_D16(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTFB_I8_D16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }

--- a/drivers/pentprim/zb8p2lit.c
+++ b/drivers/pentprim/zb8p2lit.c
@@ -253,17 +253,14 @@ lineDrawn:
 //     }
 // }
 
-void BR_ASM_CALL TriangleRender_ZTI_I8_D16_POW2(brp_block *block, int pow2, int skip_setup, va_list va) {
+void BR_ASM_CALL TriangleRender_ZTI_I8_D16_POW2(brp_block *block, int pow2, int skip_setup, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
+    /*
 	brp_vertex *v0; // [esp+18h] [ebp+Ch]
     brp_vertex *v1; // [esp+1Ch] [ebp+10h]
     brp_vertex *v2; // [esp+20h] [ebp+14h]
+    */
 
 	if (!skip_setup) {
-		v0 = va_arg(va, brp_vertex *);
-		v1 = va_arg(va, brp_vertex *);
-		v2 = va_arg(va, brp_vertex *);
-		va_end(va);
-
 		workspace.v0 = v0;
 		workspace.v1 = v1;
 		workspace.v2 = v2;
@@ -379,35 +376,29 @@ void BR_ASM_CALL TriangleRender_ZTI_I8_D16_POW2(brp_block *block, int pow2, int 
 	}
 }
 
-void BR_ASM_CALL TriangleRender_ZTI_I8_D16_8(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTI_I8_D16_8(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZTI_I8_D16_16(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTI_I8_D16_16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZTI_I8_D16_32(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTI_I8_D16_32(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZTI_I8_D16_64(brp_block *block, ...) {
-    va_list     va;
-    va_start(va, block);
-	TriangleRender_ZTI_I8_D16_POW2(block, 6, 0, va);
-	va_end(va);
+void BR_ASM_CALL TriangleRender_ZTI_I8_D16_64(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
+	TriangleRender_ZTI_I8_D16_POW2(block, 6, 0, v0, v1, v2);
 }
-void BR_ASM_CALL TriangleRender_ZTI_I8_D16_128(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTI_I8_D16_128(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZTI_I8_D16_256(brp_block *block, ...) {
-    va_list     va;
-    va_start(va, block);
-	TriangleRender_ZTI_I8_D16_POW2(block, 8, 0, va);
-	va_end(va);
+void BR_ASM_CALL TriangleRender_ZTI_I8_D16_256(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
+    TriangleRender_ZTI_I8_D16_POW2(block, 8, 0, v0, v1, v2);
 }
-void BR_ASM_CALL TriangleRender_ZTI_I8_D16_1024(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTI_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }

--- a/drivers/pentprim/zb8p2ulb.c
+++ b/drivers/pentprim/zb8p2ulb.c
@@ -262,17 +262,14 @@ lineDrawn:
 	}
 }
 
-void BR_ASM_CALL TriangleRender_ZTB_I8_D16_POW2(brp_block *block, int pow2, int skip_setup, va_list va) {
+void BR_ASM_CALL TriangleRender_ZTB_I8_D16_POW2(brp_block *block, int pow2, int skip_setup, brp_vertex* v0, brp_vertex* v1, brp_vertex* v2) {
+    /*
 	brp_vertex *v0; // [esp+18h] [ebp+Ch]
     brp_vertex *v1; // [esp+1Ch] [ebp+10h]
     brp_vertex *v2; // [esp+20h] [ebp+14h]
+	*/
 
 	if (!skip_setup) {
-		v0 = va_arg(va, brp_vertex *);
-		v1 = va_arg(va, brp_vertex *);
-		v2 = va_arg(va, brp_vertex *);
-		va_end(va);
-
 		workspace.v0 = v0;
 		workspace.v1 = v1;
 		workspace.v2 = v2;
@@ -388,36 +385,30 @@ void BR_ASM_CALL TriangleRender_ZTB_I8_D16_POW2(brp_block *block, int pow2, int 
 	}
 }
 
-void BR_ASM_CALL TriangleRender_ZTB_I8_D16_8(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTB_I8_D16_8(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZTB_I8_D16_16(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTB_I8_D16_16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZTB_I8_D16_32(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTB_I8_D16_32(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
 
-void BR_ASM_CALL TriangleRender_ZTB_I8_D16_64(brp_block *block, ...) {
-    va_list     va;
-    va_start(va, block);
-	TriangleRender_ZTB_I8_D16_POW2(block, 6, 0, va);
-	va_end(va);
+void BR_ASM_CALL TriangleRender_ZTB_I8_D16_64(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
+	TriangleRender_ZTB_I8_D16_POW2(block, 6, 0, v0, v1, v2);
 }
-void BR_ASM_CALL TriangleRender_ZTB_I8_D16_128(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTB_I8_D16_128(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZTB_I8_D16_256(brp_block *block, ...) {
-	va_list     va;
-    va_start(va, block);
-	TriangleRender_ZTB_I8_D16_POW2(block, 8, 0, va);
-	va_end(va);
+void BR_ASM_CALL TriangleRender_ZTB_I8_D16_256(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
+	TriangleRender_ZTB_I8_D16_POW2(block, 8, 0, v0, v1, v2);
 }
-void BR_ASM_CALL TriangleRender_ZTB_I8_D16_1024(brp_block *block, ...) {
+void BR_ASM_CALL TriangleRender_ZTB_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }

--- a/drivers/pentprim/zb8p2unl.c
+++ b/drivers/pentprim/zb8p2unl.c
@@ -258,17 +258,14 @@ lineDrawn:
 	}
 }
 
-void BR_ASM_CALL TriangleRender_ZT_I8_D16_POW2(brp_block *block, int pow2, int skip_setup, va_list va) {
+void BR_ASM_CALL TriangleRender_ZT_I8_D16_POW2(brp_block *block, int pow2, int skip_setup, brp_vertex* v0, brp_vertex* v1, brp_vertex* v2) {
+    /*
 	brp_vertex *v0; // [esp+18h] [ebp+Ch]
     brp_vertex *v1; // [esp+1Ch] [ebp+10h]
     brp_vertex *v2; // [esp+20h] [ebp+14h]
+	*/
 
 	if (!skip_setup) {
-		v0 = va_arg(va, brp_vertex *);
-		v1 = va_arg(va, brp_vertex *);
-		v2 = va_arg(va, brp_vertex *);
-		va_end(va);
-
 		workspace.v0 = v0;
 		workspace.v1 = v1;
 		workspace.v2 = v2;
@@ -397,22 +394,16 @@ void BR_ASM_CALL TriangleRender_ZT_I8_D16_32(brp_block *block, brp_vertex *v0, b
     BrAbort();
 }
 
-void BR_ASM_CALL TriangleRender_ZT_I8_D16_64(brp_block *block, ...) {
-    va_list     va;
-    va_start(va, block);
-	TriangleRender_ZT_I8_D16_POW2(block, 6, 0, va);
-	va_end(va);
+void BR_ASM_CALL TriangleRender_ZT_I8_D16_64(brp_block *block, brp_vertex* v0, brp_vertex* v1, brp_vertex* v2) {
+	TriangleRender_ZT_I8_D16_POW2(block, 6, 0, v0, v1, v2);
 }
 
 void BR_ASM_CALL TriangleRender_ZT_I8_D16_128(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented
     BrAbort();
 }
-void BR_ASM_CALL TriangleRender_ZT_I8_D16_256(brp_block *block, ...) {
-    va_list     va;
-    va_start(va, block);
-	TriangleRender_ZT_I8_D16_POW2(block, 8, 0, va);
-	va_end(va);
+void BR_ASM_CALL TriangleRender_ZT_I8_D16_256(brp_block *block, brp_vertex* v0, brp_vertex* v1, brp_vertex* v2) {
+	TriangleRender_ZT_I8_D16_POW2(block, 8, 0, v0, v1, v2);
 }
 void BR_ASM_CALL TriangleRender_ZT_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     // Not implemented

--- a/drivers/softrend/clip.c
+++ b/drivers/softrend/clip.c
@@ -456,7 +456,7 @@ void ClippedRenderTriangles(struct br_renderer *renderer, brp_block *block, unio
 	 * Triangulate polygon
 	 */
 	for(i = 2; i < n; i++)
-		block->render(block,&cp_in[0],&cp_in[i-1],&cp_in[i], fp_vertices, fp_edges);
+		block->render(block,&cp_in[0],&cp_in[i-1],&cp_in[i], fp_vertices, fp_edges,NULL,NULL);
 }
 
 /*
@@ -646,5 +646,5 @@ void ClippedRenderLine(struct br_renderer *renderer, brp_block *block, union brp
 	/*
 	 * Render the line
 	 */
-	block->render(block,&cp_in[0],&cp_in[1]);
+	block->render(block,&cp_in[0],&cp_in[1],NULL,NULL,NULL,NULL,NULL);
 }

--- a/drivers/softrend/convert.c
+++ b/drivers/softrend/convert.c
@@ -153,22 +153,16 @@ void BR_ASM_CALL RenderConvert1(struct brp_block *block,
 			if(m & 1)
                                 outv[0].comp_i[c] = v0->comp_i[c];
 
-	block->chain->render(block->chain, outv);
+	block->chain->render(block->chain, outv, NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
-void BR_ASM_CALL RenderConvert2(struct brp_block *block, ...)
+void BR_ASM_CALL RenderConvert2(struct brp_block *block,
+	brp_vertex *v0,
+    brp_vertex *v1)
 {
 	int c;
 	br_uint_32 m;
 	brp_vertex outv[2];
-
-    va_list va;
-	brp_vertex *v0;
-    brp_vertex *v1;
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-	va_end(va);
 
 #if BASED_FIXED
 	br_boolean has_q = (rend.block->constant_components | rend.block->vertex_components) & CM_Q;
@@ -240,24 +234,17 @@ void BR_ASM_CALL RenderConvert2(struct brp_block *block, ...)
                                 outv[1].comp_i[c] = v1->comp_i[c];
 			}
 
-	block->chain->render(block->chain, outv+0, outv+1);
+	block->chain->render(block->chain, outv+0, outv+1, NULL, NULL, NULL, NULL, NULL);
 }
 
-void BR_ASM_CALL RenderConvert3(struct brp_block *block, ...)
+void BR_ASM_CALL RenderConvert3(struct brp_block *block,
+    brp_vertex *v0,
+    brp_vertex *v1,
+    brp_vertex *v2)
 {
 	int c;
 	br_uint_32 m;
 	brp_vertex outv[3];
-
-	va_list va;
-	brp_vertex *v0;
-    brp_vertex *v1;
-	brp_vertex *v2;
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-	v2          = va_arg(va, brp_vertex *);
-	va_end(va);
 
 #if BASED_FIXED
 	br_boolean has_q = (rend.block->constant_components | rend.block->vertex_components) & CM_Q;
@@ -336,7 +323,7 @@ void BR_ASM_CALL RenderConvert3(struct brp_block *block, ...)
                                 outv[2].comp_i[c] = v2->comp_i[c];
 			}
 
-	block->chain->render(block->chain, outv+0, outv+1, outv+2);
+	block->chain->render(block->chain, outv+0, outv+1, outv+2, NULL, NULL, NULL, NULL);
 }
 
 void BR_ASM_CALL RenderConvert4(struct brp_block *block,
@@ -430,5 +417,5 @@ void BR_ASM_CALL RenderConvert4(struct brp_block *block,
                                 outv[3].comp_i[c] = v3->comp_i[c];
 			}
 
-	block->chain->render(block->chain, outv+0, outv+1, outv+2, outv+3);
+	block->chain->render(block->chain, outv+0, outv+1, outv+2, outv+3, NULL, NULL, NULL);
 }

--- a/drivers/softrend/ddi/priminfo.h
+++ b/drivers/softrend/ddi/priminfo.h
@@ -136,7 +136,14 @@ typedef union brp_vertex {
 struct brp_block; //added to quiet compiler
 
 #ifndef __H2INC__
-typedef void BR_ASM_CALL brp_render_fn(struct brp_block *block, ...);
+typedef void BR_ASM_CALL brp_render_fn(struct brp_block *block,
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp);
 #else
 typedef void BR_ASM_CALL brp_render_fn(struct brp_block *block);
 #endif

--- a/drivers/softrend/drv_ip.h
+++ b/drivers/softrend/drv_ip.h
@@ -224,8 +224,10 @@ br_error BR_CMETHOD_DECL(br_geometry_v1_model_soft, renderOnScreen)
  */
 void BR_ASM_CALL RenderConvert1(struct brp_block *block,
 	brp_vertex *v0);
-void BR_ASM_CALL RenderConvert2(struct brp_block *block, ...);
-void BR_ASM_CALL RenderConvert3(struct brp_block *block, ...);
+void BR_ASM_CALL RenderConvert2(struct brp_block *block,
+	brp_vertex *v0, brp_vertex *v1);
+void BR_ASM_CALL RenderConvert3(struct brp_block *block,
+	brp_vertex *v0, brp_vertex *v1,brp_vertex *v2);
 void BR_ASM_CALL RenderConvert4(struct brp_block *block,
 	brp_vertex *v0, brp_vertex *v1,brp_vertex *v2,brp_vertex *v3);
 
@@ -309,7 +311,14 @@ void SURFACE_CALL SurfaceMapGeometryMapScaleTranslate(br_renderer *self, br_vect
 void SURFACE_CALL SurfaceMapGeometryMapCopy(br_renderer *self, br_vector3 *p, br_vector2 *map, br_vector3 *n, br_colour colour, br_scalar *comp);
 void SURFACE_CALL SurfaceMapGeometryMapShift(br_renderer *self, br_vector3 *p, br_vector2 *map, br_vector3 *n, br_colour colour, br_scalar *comp);
 
-void BR_ASM_CALL OpTriangleMapQuad(struct brp_block *block, ...);
+void BR_ASM_CALL OpTriangleMapQuad(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp);
 
 /*
  * alpha.c
@@ -325,26 +334,112 @@ void SURFACE_CALL SurfaceLinearDepth(br_renderer *self, br_vector3 *p, br_vector
 /*
  * faceops.c
  */
-void BR_ASM_CALL OpTriangleClip(struct brp_block *block, ...);
-void BR_ASM_CALL OpTriangleClipConstantSurf(struct brp_block *block, ...);
-void BR_ASM_CALL OpTriangleConstantSurf(struct brp_block *block, ...);
-void BR_ASM_CALL OpTriangleTwoSidedConstantSurf(struct brp_block *block, ...);
+void BR_ASM_CALL OpTriangleClip(struct brp_block *block,
+	brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp);
+void BR_ASM_CALL OpTriangleClipConstantSurf(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp);
+void BR_ASM_CALL OpTriangleConstantSurf(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp);
+void BR_ASM_CALL OpTriangleTwoSidedConstantSurf(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp);
 
-void BR_ASM_CALL OpTriangleMappingWrapFix(struct brp_block *block, ...);
+void BR_ASM_CALL OpTriangleMappingWrapFix(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp);
 
-void BR_ASM_CALL OpTriangleRelightTwoSided(struct brp_block *block, ...);
+void BR_ASM_CALL OpTriangleRelightTwoSided(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp);
 
-void BR_ASM_CALL OpTriangleToLines(struct brp_block *block, ...);
-void BR_ASM_CALL OpTriangleReplicateConstant(struct brp_block *block, ...);
-void BR_ASM_CALL OpTriangleReplicateConstantI(struct brp_block *block, ...);
-void BR_ASM_CALL OpTriangleReplicateConstantRGB(struct brp_block *block, ...);
-void BR_ASM_CALL OpTriangleToPoints(struct brp_block *block, ...);
-void BR_ASM_CALL OpTriangleToPoints_OS(struct brp_block *block, ...);
-void BR_ASM_CALL OpLineClip(struct brp_block *block, ...);
+void BR_ASM_CALL OpTriangleToLines(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges);
+void BR_ASM_CALL OpTriangleReplicateConstant(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges);
+void BR_ASM_CALL OpTriangleReplicateConstantI(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges);
+void BR_ASM_CALL OpTriangleReplicateConstantRGB(struct brp_block *block, 
+	    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges);
+void BR_ASM_CALL OpTriangleToPoints(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices);
+void BR_ASM_CALL OpTriangleToPoints_OS(struct brp_block *block, 
+        brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices);
+void BR_ASM_CALL OpLineClip(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1);
 
-void BR_ASM_CALL OpTriangleSubdivide(struct brp_block *block, ...);
+void BR_ASM_CALL OpTriangleSubdivide(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp);
 
-void BR_ASM_CALL OpTriangleSubdivideOnScreen(struct brp_block *block, ...);
+void BR_ASM_CALL OpTriangleSubdivideOnScreen(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp);
 
 void SubdivideSetThreshold(br_int_32 subdivide_tolerance);
 

--- a/drivers/softrend/faceops.c
+++ b/drivers/softrend/faceops.c
@@ -20,32 +20,18 @@ BR_RCS_ID("$Id: faceops.c 1.4 1998/07/27 14:55:50 jon Exp $");
 /*
  * Clip a triangle
  */
-void BR_ASM_CALL OpTriangleClip(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleClip(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp)
 {
 	brp_vertex clip_in[3];
 	int nclipped;
 	brp_vertex *clipped;
-
-	va_list va;
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-    br_uint_16 *fp_edges;
-    br_vector4       *fp_eqn;
-    struct temp_face *tfp;
-
-	va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16*);
-    fp_edges    = va_arg(va, br_uint_16*);
-    fp_eqn      = va_arg(va, br_vector4 *);
-    tfp         = va_arg(va, struct temp_face *);
-    va_end(va);
-
-
 
 	clip_in[0] = *v0; clip_in[1] = *v1; clip_in[2] = *v2;
 
@@ -56,7 +42,14 @@ void BR_ASM_CALL OpTriangleClip(struct brp_block *block, ...)
 /*
  * Clip a triangle and generate per primitive components
  */
-void BR_ASM_CALL OpTriangleClipConstantSurf(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleClipConstantSurf(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp)
 {
 	brp_vertex clip_in[3];
 	int nclipped,i;
@@ -65,25 +58,6 @@ void BR_ASM_CALL OpTriangleClipConstantSurf(struct brp_block *block, ...)
 	br_vector2 *vp_map;
 	br_colour colour = scache.colour;
 	br_vector3 rev_normal;
-
-	va_list va;
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-    br_uint_16 *fp_edges;
-    br_vector4       *fp_eqn;
-    struct temp_face *tfp;
-
-	va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16 *);
-    fp_edges    = va_arg(va, br_uint_16 *);
-    fp_eqn      = va_arg(va, br_vector4 *);
-    tfp         = va_arg(va, struct temp_face *);
-    va_end(va);
 
 	/*
      * Face needs to be clipped
@@ -118,32 +92,19 @@ void BR_ASM_CALL OpTriangleClipConstantSurf(struct brp_block *block, ...)
 /*
  * Generate per primitive components
  */
-void BR_ASM_CALL OpTriangleConstantSurf(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleConstantSurf(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp)
 {
 	br_vector3 *vp_p;
 	br_vector2 *vp_map;
 	br_colour colour = scache.colour;
 	int i;
-
-	va_list va;
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-    br_uint_16* fp_edges;
-
-    br_vector4       *fp_eqn;
-    struct temp_face *tfp;
-
-	va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16*);
-    fp_edges = va_arg(va, br_uint_16*);
-    fp_eqn      = va_arg(va, br_vector4 *);
-    tfp         = va_arg(va, struct temp_face *);
-    va_end(va);
 
 	vp_p = rend.vertex_p + fp_vertices[0];
 	vp_map = rend.vertex_map + fp_vertices[0];
@@ -154,35 +115,23 @@ void BR_ASM_CALL OpTriangleConstantSurf(struct brp_block *block, ...)
 	for(i=0; i < rend.renderer->state.cache.nconstant_fns; i++)
 		rend.renderer->state.cache.constant_fns[i](rend.renderer, vp_p, vp_map, (br_vector3 *)fp_eqn, colour, v0->comp);
 
-	block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges);
+	block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges, NULL, NULL);
 }
 
-void BR_ASM_CALL OpTriangleTwoSidedConstantSurf(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleTwoSidedConstantSurf(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp)
 {
 	br_vector3 *vp_p;
 	br_vector2 *vp_map;
 	br_colour colour = scache.colour;
 	br_vector3 rev_normal;
 	int i;
-
-	va_list va;
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-    br_uint_16* fp_edges;
-    br_vector4       *fp_eqn;
-    struct temp_face *tfp;
-
-	va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16*);
-    fp_edges    = va_arg(va, br_uint_16*);
-    fp_eqn      = va_arg(va, br_vector4 *);
-    tfp         = va_arg(va, struct temp_face *);
-    va_end(va);
 
 	vp_p = rend.vertex_p + fp_vertices[0];
 	vp_map = rend.vertex_map + fp_vertices[0];
@@ -202,37 +151,25 @@ void BR_ASM_CALL OpTriangleTwoSidedConstantSurf(struct brp_block *block, ...)
 			rend.renderer->state.cache.constant_fns[i](rend.renderer, vp_p, vp_map, (br_vector3 *)fp_eqn, colour, v0->comp);
 	}
 
-	block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges);
+	block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges, NULL, NULL);
 }
 
 /*
  * Fix up ugly seams in environment mapping
  */
-void BR_ASM_CALL OpTriangleMappingWrapFix(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleMappingWrapFix(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp)
 {
 	br_scalar scale = BR_ABS(rend.renderer->state.cache.comp_scales[C_U]);
 	br_scalar half = BR_CONST_DIV(scale,2);
 	br_scalar d0,d1,d2;
 	brp_vertex fixed[3];
-
-    va_list va;
-	brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-    br_uint_16* fp_edges;
-    br_vector4       *fp_eqn;
-    struct temp_face *tfp;
-
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16*);
-    fp_edges    = va_arg(va, br_uint_16*);
-    fp_eqn      = va_arg(va, br_vector4 *);
-    tfp         = va_arg(va, struct temp_face *);
-    va_end(va);
 
 	/*
 	 * If change in U along any edge is > 0.5, then adjust one of the vertices to bring it
@@ -272,7 +209,14 @@ void BR_ASM_CALL OpTriangleMappingWrapFix(struct brp_block *block, ...)
 /*
  * handle relighting of vertices if a triangle is two-sided
  */
-void BR_ASM_CALL OpTriangleRelightTwoSided(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleRelightTwoSided(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp)
 {
 	int i,v;
 	br_vector3 *vp_p;
@@ -281,25 +225,6 @@ void BR_ASM_CALL OpTriangleRelightTwoSided(struct brp_block *block, ...)
 	brp_vertex tv[3];
    	br_vector3 rev_normal;
 	br_colour colour = scache.colour;
-
-	va_list va;
-	brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-    br_uint_16* fp_edges;
-    br_vector4       *fp_eqn;
-    struct temp_face *tfp;
-
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16*);
-    fp_edges    = va_arg(va, br_uint_16*);
-    fp_eqn      = va_arg(va, br_vector4 *);
-    tfp         = va_arg(va, struct temp_face *);
-    va_end(va);
 
 	if(tfp->flag & TFF_REVERSED) {
 
@@ -337,39 +262,28 @@ void BR_ASM_CALL OpTriangleRelightTwoSided(struct brp_block *block, ...)
 /*
  * Convert a triangle to lines
  */
-void BR_ASM_CALL OpTriangleToLines(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleToLines(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges)
 {
-
-	brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-    br_uint_16* fp_edges;
-
-    va_list va;
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16*);
-    fp_edges    = va_arg(va, br_uint_16*);
-    va_end(va);
-
 	/*
 	 * Generate a line for each unrendered edge
 	 */
 	if(!rend.edge_flags[fp_edges[0]]) {
-		block->chain->render(block->chain, v0, v1);
+		block->chain->render(block->chain, v0, v1, NULL, NULL, NULL, NULL, NULL);
 		rend.edge_flags[fp_edges[0]] = 1;
 	}
 
 	if(!rend.edge_flags[fp_edges[1]]) {
-		block->chain->render(block->chain, v1, v2);
+		block->chain->render(block->chain, v1, v2, NULL, NULL, NULL, NULL, NULL);
 		rend.edge_flags[fp_edges[1]] = 1;
 	}
 
 	if(!rend.edge_flags[fp_edges[2]]) {
-		block->chain->render(block->chain, v2, v0);
+		block->chain->render(block->chain, v2, v0, NULL, NULL, NULL, NULL, NULL);
 		rend.edge_flags[fp_edges[2]] = 1;
 	}
 }
@@ -378,25 +292,15 @@ void BR_ASM_CALL OpTriangleToLines(struct brp_block *block, ...)
  * Copy constant components from vertex 0 to all other vertices (used prior to breaking
  * point into lines and points, or to use interpolated renderers for constant settings)
  */
-void BR_ASM_CALL OpTriangleReplicateConstant(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleReplicateConstant(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges)
 {
 	br_uint_32 m;
 	int c;
-
-	brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-    br_uint_16* fp_edges;
-
-    va_list va;
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16*);
-    fp_edges    = va_arg(va, br_uint_16*);
-    va_end(va);
 
 	m = rend.block->constant_mask;
 
@@ -405,140 +309,96 @@ void BR_ASM_CALL OpTriangleReplicateConstant(struct brp_block *block, ...)
 			v1->comp[c] = v2->comp[c] = v0->comp[c];
 	}
 
-	block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges);
+	block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges, NULL, NULL);
 }
 
 /*
  * Special case for just I
  */
-void BR_ASM_CALL OpTriangleReplicateConstantI(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleReplicateConstantI(struct brp_block *block,
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges)
 {
-	brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-    br_uint_16* fp_edges;
-
-    va_list va;
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16*);
-    fp_edges    = va_arg(va, br_uint_16*);
-    va_end(va);
-
 	v1->comp[C_I] = v2->comp[C_I] = v0->comp[C_I];
 
-	block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges);
+	block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges, NULL, NULL);
 }
 
 /*
  * Special case for just RGB
  */
-void BR_ASM_CALL OpTriangleReplicateConstantRGB(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleReplicateConstantRGB(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges)
 {
-	brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-    br_uint_16* fp_edges;
-
-    va_list va;
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16*);
-    fp_edges    = va_arg(va, br_uint_16*);
-    va_end(va);
-
 	v1->comp[C_R] = v2->comp[C_R] = v0->comp[C_R];
 	v1->comp[C_G] = v2->comp[C_G] = v0->comp[C_G];
 	v1->comp[C_B] = v2->comp[C_B] = v0->comp[C_B];
 
-	block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges);
+	block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges, NULL, NULL);
 }
 
-void BR_ASM_CALL OpTriangleToPoints(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleToPoints(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices)
 {
-	brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-
-    va_list va;
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16*);
-    va_end(va);
 	/*
 	 * Generate a point for each unrendered vertex
 	 */
 	if(!rend.vertex_flags[fp_vertices[0]] && !(v0->flags & OUTCODES_ALL)) {
-		block->chain->render(block->chain, v0);
+		block->chain->render(block->chain, v0, NULL, NULL, NULL, NULL, NULL, NULL);
 		rend.vertex_flags[fp_vertices[0]] = 1;
 	}
 
 	if(!rend.vertex_flags[fp_vertices[1]] && !(v1->flags & OUTCODES_ALL)) {
-		block->chain->render(block->chain, v1);
+		block->chain->render(block->chain, v1, NULL, NULL, NULL, NULL, NULL, NULL);
 		rend.vertex_flags[fp_vertices[1]] = 1;
 	}
 
 	if(!rend.vertex_flags[fp_vertices[2]] && !(v2->flags & OUTCODES_ALL)) {
-		block->chain->render(block->chain, v2);
+		block->chain->render(block->chain, v2, NULL, NULL, NULL, NULL, NULL, NULL);
 		rend.vertex_flags[fp_vertices[2]] = 1;
 	}
 }
 
-void BR_ASM_CALL OpTriangleToPoints_OS(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleToPoints_OS(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices)
 {
-	brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-
-    va_list va;
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16*);
-    va_end(va);
-
 	/*
 	 * Generate a point for each unrendered vertex
 	 */
 	if(!rend.vertex_flags[fp_vertices[0]]) {
-		block->chain->render(block->chain, v0);
+		block->chain->render(block->chain, v0, NULL, NULL, NULL, NULL, NULL, NULL);
 		rend.vertex_flags[fp_vertices[0]] = 1;
 	}
 
 	if(!rend.vertex_flags[fp_vertices[1]]) {
-		block->chain->render(block->chain, v1);
+		block->chain->render(block->chain, v1, NULL, NULL, NULL, NULL, NULL, NULL);
 		rend.vertex_flags[fp_vertices[1]] = 1;
 	}
 
 	if(!rend.vertex_flags[fp_vertices[2]]) {
-		block->chain->render(block->chain, v2);
+		block->chain->render(block->chain, v2, NULL, NULL, NULL, NULL, NULL, NULL);
 		rend.vertex_flags[fp_vertices[2]] = 1;
 	}
 }
 
-void BR_ASM_CALL OpLineClip(struct brp_block *block, ...)
+void BR_ASM_CALL OpLineClip(struct brp_block *block,
+    brp_vertex* v0,
+    brp_vertex* v1)
 {
 	brp_vertex clipped[2];
-
-	brp_vertex *v0;
-    brp_vertex *v1;
-
-    va_list va;
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    va_end(va);
 
 	if(ClipLine(rend.renderer, clipped, v0, v1, rend.renderer->state.cache.clip_slots, v0->flags | v1->flags))
 		ClippedRenderLine(rend.renderer, block->chain, clipped);
@@ -790,7 +650,14 @@ static void triangleSubdivideCheck(int depth, struct brp_block *block, brp_verte
 /*
  * Faces ops for subdivision
  */
-void BR_ASM_CALL OpTriangleSubdivide(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleSubdivide(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp)
 {
 	brp_vertex clip_in[3];
 	int nclipped,i;
@@ -800,28 +667,17 @@ void BR_ASM_CALL OpTriangleSubdivide(struct brp_block *block, ...)
 	br_colour colour = scache.colour;
 	br_vector3 rev_normal;
 
-	va_list va;
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-    br_uint_16* fp_edges;
-    br_vector4       *fp_eqn;
-    struct temp_face *tfp;
-
-	va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16*);
-    fp_edges    = va_arg(va, br_uint_16*);
-    fp_eqn      = va_arg(va, br_vector4 *);
-    tfp         = va_arg(va, struct temp_face *);
-    va_end(va);
     triangleSubdivide(6, block, v0,v1,v2, fp_vertices, fp_edges, fp_eqn, tfp);
 }
 
-void BR_ASM_CALL OpTriangleSubdivideOnScreen(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleSubdivideOnScreen(struct brp_block *block,
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp)
 {
 	brp_vertex clip_in[3];
 	int nclipped,i;
@@ -830,25 +686,6 @@ void BR_ASM_CALL OpTriangleSubdivideOnScreen(struct brp_block *block, ...)
 	br_vector2 *vp_map;
 	br_colour colour = scache.colour;
 	br_vector3 rev_normal;
-
-	va_list va;
-    brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-    br_uint_16* fp_edges;
-    br_vector4       *fp_eqn;
-    struct temp_face *tfp;
-
-	va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16*);
-    fp_edges    = va_arg(va, br_uint_16*);
-    fp_eqn      = va_arg(va, br_vector4 *);
-    tfp         = va_arg(va, struct temp_face *);
-    va_end(va);
 
     triangleSubdivideOnScreen(6, block, v0,v1,v2, fp_vertices, fp_edges, fp_eqn, tfp);
 }

--- a/drivers/softrend/ffront.c
+++ b/drivers/softrend/ffront.c
@@ -24,7 +24,7 @@ void BR_ASM_CALL RenderForceFront1(struct brp_block *block,
 
 	v[0].comp[C_SZ] = BR_SCALAR(0.0);
 
-	block->chain->render(block->chain, v+0);
+	block->chain->render(block->chain, v+0, NULL, NULL, NULL, NULL, NULL, NULL);
 }
 
 void BR_ASM_CALL RenderForceFront2(struct brp_block *block,
@@ -38,7 +38,7 @@ void BR_ASM_CALL RenderForceFront2(struct brp_block *block,
 	v[0].comp[C_SZ] = BR_SCALAR(0.0);
 	v[1].comp[C_SZ] = BR_SCALAR(0.0);
 
-	block->chain->render(block->chain, v+0, v+1);
+	block->chain->render(block->chain, v+0, v+1, NULL, NULL, NULL, NULL, NULL);
 }
 
 void BR_ASM_CALL RenderForceFront3(struct brp_block *block,
@@ -54,7 +54,7 @@ void BR_ASM_CALL RenderForceFront3(struct brp_block *block,
 	v[1].comp[C_SZ] = BR_SCALAR(0.0);
 	v[2].comp[C_SZ] = BR_SCALAR(0.0);
 
-	block->chain->render(block->chain, v+0, v+1, v+2);
+	block->chain->render(block->chain, v+0, v+1, v+2, NULL, NULL, NULL, NULL);
 }
 
 void BR_ASM_CALL RenderForceFront4(struct brp_block *block,
@@ -72,6 +72,6 @@ void BR_ASM_CALL RenderForceFront4(struct brp_block *block,
 	v[2].comp[C_SZ] = BR_SCALAR(0.0);
 	v[3].comp[C_SZ] = BR_SCALAR(0.0);
 
-	block->chain->render(block->chain, v+0, v+1, v+2, v+3);
+	block->chain->render(block->chain, v+0, v+1, v+2, v+3, NULL, NULL, NULL);
 }
 

--- a/drivers/softrend/gv1buckt.c
+++ b/drivers/softrend/gv1buckt.c
@@ -139,7 +139,7 @@ br_error BR_CMETHOD_DECL(br_geometry_v1_buckets_soft, render)
 			/*
 			 * Render the primitive
 			 */
-			rend.block->render(rend.block,p->v[0],p->v[1],p->v[2]);
+			rend.block->render(rend.block,p->v[0],p->v[1],p->v[2], NULL, NULL, NULL, NULL);
 		}
 	}
 

--- a/drivers/softrend/mapping.c
+++ b/drivers/softrend/mapping.c
@@ -187,27 +187,15 @@ void SURFACE_CALL SurfaceMapGeometryMapShift(br_renderer *self,
 #endif
 
 #ifndef OpTriangleMapQuad
-void BR_ASM_CALL OpTriangleMapQuad(struct brp_block *block, ...)
+void BR_ASM_CALL OpTriangleMapQuad(struct brp_block *block, 
+    brp_vertex* v0,
+    brp_vertex* v1,
+    brp_vertex* v2,
+    br_uint_16* fp_vertices,
+    br_uint_16* fp_edges,
+    br_vector4* fp_eqn,
+    struct temp_face* tfp)
 {
-	va_list va;
-	brp_vertex *v0;
-    brp_vertex *v1;
-    brp_vertex *v2;
-    br_uint_16 *fp_vertices;
-    br_uint_16* fp_edges;
-    br_vector4   *fp_eqn;
-    struct temp_face *tfp;
-
-    va_start(va, block);
-    v0          = va_arg(va, brp_vertex *);
-    v1          = va_arg(va, brp_vertex *);
-    v2          = va_arg(va, brp_vertex *);
-    fp_vertices = va_arg(va, br_uint_16*);
-    fp_edges    = va_arg(va, br_uint_16*);
-    fp_eqn      = va_arg(va, br_vector4 *);
-    tfp         = va_arg(va, struct temp_face *);
-    va_end(va);
-
 	br_vector2 *qv = (br_vector2 *)&rend.renderer->state.cache.quad_transformed;
 
 	switch (rend.face_flags[rend.current_index] & BR_FACEF_QUAD_MASK) {


### PR DESCRIPTION
I changed the function signatures in the software renderer so there's no need to use varargs. The rationale behind this is to allow better code generation, e.g. passing arguments by registers where the ABI permits. I tried to minimize whitespace changes, but it did slip in with copy pastes. Let me know if I should do any changes on this.