### PR TITLE
cmake: OpenGL is loaded dynamically

### DIFF
--- a/drivers/glrend/CMakeLists.txt
+++ b/drivers/glrend/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(glrend)
 
-find_package(OpenGL REQUIRED COMPONENTS OpenGL)
-
 # Embed shaders
 add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/default.vert.glsl.h"
@@ -155,7 +153,7 @@ endif ()
 
 target_include_directories(glrend PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(glrend PRIVATE OpenGL::GL BRender::DDI)
+target_link_libraries(glrend PRIVATE BRender::DDI)
 target_link_libraries(glrend PUBLIC glrend-headers)
 
 set_target_properties(glrend PROPERTIES


### PR DESCRIPTION
glad loads OpenGL dynamically using the `GLADloadproc` argument of `gladLoadGLLoader`.

https://github.com/dethrace-labs/BRender-v1.3.2/blob/89861762c3e0743eed484ef5dace8e882ecd1289/drivers/glrend/include/glad/glad.h#L85

This change makes OpenGL an optional dependency of dethrace: you can always use the software renderer.