### PR TITLE
cmake: disable install by default when built as subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(Perl REQUIRED)
 
 option(BRENDER_BUILD_DRIVERS "Build Drivers" ON)
-option(BRENDER_BUILD_EXAMPLES "Build Examples" OFF)
+option(BRENDER_BUILD_EXAMPLES "Build Examples" "${BRender_IS_TOPLEVEL}")
 option(BRENDER_INSTALL "Enable installation" "${BRender_IS_TOPLEVEL}")
 option(BRENDER_ASAN_ENABLED "Address Sanitizer" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,9 @@ add_subdirectory(core)
 
 add_subdirectory(x86emu)
 
-if (BRENDER_BUILD_DRIVERS)
+if(BRENDER_BUILD_DRIVERS)
     add_subdirectory(drivers)
-endif ()
+endif()
 
 ##
 # Core BRender, no drivers, no DDI.
@@ -41,15 +41,15 @@ add_library(BRender::Full ALIAS brender-full)
 add_library(BRender::DDI ALIAS brender-ddi)
 
 
-# if (BRENDER_BUILD_TOOLS)
+# if(BRENDER_BUILD_TOOLS)
 #     add_subdirectory(tools)
-# endif ()
+# endif()
 
-if (BRENDER_BUILD_EXAMPLES)
+if(BRENDER_BUILD_EXAMPLES)
     add_subdirectory(examples)
-endif ()
+endif()
 
-if (NOT BRENDER_DISABLE_INSTALL)
+if(NOT BRENDER_DISABLE_INSTALL)
     include(cmake/packaging.cmake)
     include(CPack)
-endif ()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(Perl REQUIRED)
 
 option(BRENDER_BUILD_DRIVERS "Build Drivers" ON)
 option(BRENDER_BUILD_EXAMPLES "Build Examples" OFF)
-option(BRENDER_DISABLE_INSTALL "Disable installation" OFF)
+option(BRENDER_INSTALL "Enable installation" "${BRender_IS_TOPLEVEL}")
 option(BRENDER_ASAN_ENABLED "Address Sanitizer" OFF)
 
 add_subdirectory(core)
@@ -49,7 +49,7 @@ if(BRENDER_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-if(NOT BRENDER_DISABLE_INSTALL)
+if(BRENDER_INSTALL)
     include(cmake/packaging.cmake)
     include(CPack)
 endif()

--- a/core/math/CMakeLists.txt
+++ b/core/math/CMakeLists.txt
@@ -52,6 +52,6 @@ target_compile_definitions(math PRIVATE __BR_V1DB__=0)
 target_link_libraries(math PRIVATE brender-inc-ddi)
 
 find_library(math_library m)
-if (math_library)
+if(math_library)
     target_link_libraries(math PUBLIC ${math_library})
-endif ()
+endif()

--- a/drivers/glrend/CMakeLists.txt
+++ b/drivers/glrend/CMakeLists.txt
@@ -147,9 +147,9 @@ add_library(glrend
         )
 
 get_target_property(target_type glrend TYPE)
-if (target_type STREQUAL SHARED_LIBRARY)
+if(target_type STREQUAL SHARED_LIBRARY)
     target_compile_definitions(glrend PRIVATE -DDEFINE_BR_ENTRY_POINT)
-endif ()
+endif()
 
 target_include_directories(glrend PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 


### PR DESCRIPTION
I noticed dethrace binary ci packages contained BRender development files