### PR TITLE
Adds missing size render functions

### DIFF
--- a/drivers/pentprim/zb8p2lit.c
+++ b/drivers/pentprim/zb8p2lit.c
@@ -365,12 +365,10 @@ void BR_ASM_CALL TriangleRender_ZTI_I8_D16_POW2(brp_block *block, int pow2, int 
 }
 
 void BR_ASM_CALL TriangleRender_ZTI_I8_D16_8(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
-    // Not implemented
-    BrAbort();
+    TriangleRender_ZTI_I8_D16_POW2(block, 3, 0, v0, v1, v2);
 }
 void BR_ASM_CALL TriangleRender_ZTI_I8_D16_16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
-    // Not implemented
-    BrAbort();
+    TriangleRender_ZTI_I8_D16_POW2(block, 4, 0, v0, v1, v2);
 }
 void BR_ASM_CALL TriangleRender_ZTI_I8_D16_32(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
     TriangleRender_ZTI_I8_D16_POW2(block, 5, 0, v0, v1, v2);
@@ -385,6 +383,5 @@ void BR_ASM_CALL TriangleRender_ZTI_I8_D16_256(brp_block *block, brp_vertex *v0,
     TriangleRender_ZTI_I8_D16_POW2(block, 8, 0, v0, v1, v2);
 }
 void BR_ASM_CALL TriangleRender_ZTI_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
-    // Not implemented
-    BrAbort();
+    TriangleRender_ZTI_I8_D16_POW2(block, 10, 0, v0, v1, v2);
 }

--- a/drivers/pentprim/zb8p2ulb.c
+++ b/drivers/pentprim/zb8p2ulb.c
@@ -386,29 +386,29 @@ void BR_ASM_CALL TriangleRender_ZTB_I8_D16_POW2(brp_block *block, int pow2, int 
 }
 
 void BR_ASM_CALL TriangleRender_ZTB_I8_D16_8(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
-    // Not implemented
-    BrAbort();
+    TriangleRender_ZTB_I8_D16_POW2(block, 3, 0, v0, v1, v2);
 }
+
 void BR_ASM_CALL TriangleRender_ZTB_I8_D16_16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
-    // Not implemented
-    BrAbort();
+    TriangleRender_ZTB_I8_D16_POW2(block, 4, 0, v0, v1, v2);
 }
+
 void BR_ASM_CALL TriangleRender_ZTB_I8_D16_32(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
-    // Not implemented
-    BrAbort();
+    TriangleRender_ZTB_I8_D16_POW2(block, 5, 0, v0, v1, v2);
 }
 
 void BR_ASM_CALL TriangleRender_ZTB_I8_D16_64(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
 	TriangleRender_ZTB_I8_D16_POW2(block, 6, 0, v0, v1, v2);
 }
+
 void BR_ASM_CALL TriangleRender_ZTB_I8_D16_128(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
-    // Not implemented
-    BrAbort();
+    TriangleRender_ZTB_I8_D16_POW2(block, 7, 0, v0, v1, v2);
 }
+
 void BR_ASM_CALL TriangleRender_ZTB_I8_D16_256(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
 	TriangleRender_ZTB_I8_D16_POW2(block, 8, 0, v0, v1, v2);
 }
+
 void BR_ASM_CALL TriangleRender_ZTB_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
-    // Not implemented
-    BrAbort();
+    TriangleRender_ZTB_I8_D16_POW2(block, 10, 0, v0, v1, v2);
 }

--- a/drivers/pentprim/zb8p2unl.c
+++ b/drivers/pentprim/zb8p2unl.c
@@ -382,16 +382,15 @@ void BR_ASM_CALL TriangleRender_ZT_I8_D16_POW2(brp_block *block, int pow2, int s
 }
 
 void BR_ASM_CALL TriangleRender_ZT_I8_D16_8(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
-    // Not implemented
-    BrAbort();
+    TriangleRender_ZT_I8_D16_POW2(block, 3, 0, v0, v1, v2);
 }
+
 void BR_ASM_CALL TriangleRender_ZT_I8_D16_16(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
-    // Not implemented
-    BrAbort();
+    TriangleRender_ZT_I8_D16_POW2(block, 4, 0, v0, v1, v2);
 }
+
 void BR_ASM_CALL TriangleRender_ZT_I8_D16_32(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
-    // Not implemented
-    BrAbort();
+    TriangleRender_ZT_I8_D16_POW2(block, 5, 0, v0, v1, v2);
 }
 
 void BR_ASM_CALL TriangleRender_ZT_I8_D16_64(brp_block *block, brp_vertex* v0, brp_vertex* v1, brp_vertex* v2) {
@@ -399,13 +398,13 @@ void BR_ASM_CALL TriangleRender_ZT_I8_D16_64(brp_block *block, brp_vertex* v0, b
 }
 
 void BR_ASM_CALL TriangleRender_ZT_I8_D16_128(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
-    // Not implemented
-    BrAbort();
+    TriangleRender_ZT_I8_D16_POW2(block, 7, 0, v0, v1, v2);
 }
+
 void BR_ASM_CALL TriangleRender_ZT_I8_D16_256(brp_block *block, brp_vertex* v0, brp_vertex* v1, brp_vertex* v2) {
 	TriangleRender_ZT_I8_D16_POW2(block, 8, 0, v0, v1, v2);
 }
+
 void BR_ASM_CALL TriangleRender_ZT_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
-    // Not implemented
-    BrAbort();
+    TriangleRender_ZTB_I8_D16_POW2(block, 10, 0, v0, v1, v2);
 }

--- a/drivers/pentprim/zb8p2unl.c
+++ b/drivers/pentprim/zb8p2unl.c
@@ -406,5 +406,5 @@ void BR_ASM_CALL TriangleRender_ZT_I8_D16_256(brp_block *block, brp_vertex* v0, 
 }
 
 void BR_ASM_CALL TriangleRender_ZT_I8_D16_1024(brp_block *block, brp_vertex *v0, brp_vertex *v1,brp_vertex *v2) {
-    TriangleRender_ZTB_I8_D16_POW2(block, 10, 0, v0, v1, v2);
+    TriangleRender_ZT_I8_D16_POW2(block, 10, 0, v0, v1, v2);
 }


### PR DESCRIPTION
Industrial Injury in MeldPack had a 32x32 unlit zbuffered textured triangle which caused a crash as `TriangleRender_ZT_I8_D16_32` was unimplemented. 

Added some extra specific sized implementations