### PR TITLE
Support Windows crlf

### DIFF
--- a/drivers/glrend/video.c
+++ b/drivers/glrend/video.c
@@ -41,8 +41,8 @@ char* preprocessShader(char* shader, size_t size) {
     for (i = 0; i < size; i++) {
         line[line_i] = shader[i];
         line[line_i+1] = '\0';
-        line_i++;
-        if (shader[i] == '\n') {
+        if (shader[i] == '\n' || shader[i] == '\r') {
+            line[line_i] = '\n';
             // we've captured a whole line
             if (strcmp(line, "##ifdef GL_ES\n") == 0) {
                 filter_state = 1;
@@ -59,7 +59,12 @@ char* preprocessShader(char* shader, size_t size) {
                     strcat(processed, line);
                 }
             }
+            if (shader[i] == '\r' && shader[i+1] == '\n') {
+                i++;
+            }
             line_i = 0;
+        } else {
+            line_i++;
         }
     }
     return processed;

--- a/drivers/glrend/video.c
+++ b/drivers/glrend/video.c
@@ -36,7 +36,7 @@ char* preprocessShader(char* shader, size_t size) {
     filter_state = 0;
     is_context_opengles = glContextIsOpenGLES();
     processed = BrScratchAllocate(size);
-    BrMemSet(processed, 0, sizeof(processed));
+    processed[0] = '\0';
 
     for (i = 0; i < size; i++) {
         line[line_i] = shader[i];


### PR DESCRIPTION
The shaders on CI contained CRLF (`\r\n`) characters, causing the custom preprocessor to let everything through.

Compiling the unpreprocessed files caused compilation to fail with the following message:
```
WARNING: 0:1: '' :  #version directive missing
FLEX: Unknown char #
ERROR: 0:1: '#' : syntax error syntax error\n
```