### PR TITLE
glrend: print name of GL error

### DIFF
--- a/drivers/glrend/glassert.c
+++ b/drivers/glrend/glassert.c
@@ -3,8 +3,18 @@
 // todo assert or warn based on a flag
 void GL_AssertOrWarnIfError(char *file, int line) {
     int e;
+    const char *kind;
     e = glGetError();
-    if (e != 0) {
-        BrWarning("GL error: %s:%d %d\n", file, line, e);
+    if (e == GL_NO_ERROR) {
+        return;
     }
+    switch (e) {
+        case GL_INVALID_ENUM:                   kind = "GL_INVALID_ENUM"; break;
+        case GL_INVALID_VALUE:                  kind = "GL_INVALID_VALUE"; break;
+        case GL_INVALID_OPERATION:              kind = "GL_INVALID_OPERATION"; break;
+        case GL_INVALID_FRAMEBUFFER_OPERATION:  kind = "GL_INVALID_FRAMEBUFFER_OPERATION"; break;
+        case GL_OUT_OF_MEMORY:                  kind = "GL_OUT_OF_MEMORY"; break;
+        default:                                kind = "<unknown>"; break;
+    }
+    BrWarning("GL error: %s:%d %s (0x%x)\n", file, line, kind, e);
 }


### PR DESCRIPTION
I am occasionally seeing GL errors when using the action replay.
This pr won't fix them but will show a little bit more information.