### PR TITLE
Fix UBSAN runtime errors

### DIFF
--- a/core/fw/mem.c
+++ b/core/fw/mem.c
@@ -30,7 +30,9 @@ void * BR_RESIDENT_ENTRY BrMemAllocate(br_size_t size, br_uint_8 type)
 	/*
 	 * Clear block
 	 */
-	BrMemSet(b,0,size);
+	if (b != NULL || size != 0) {
+		BrMemSet(b,0,size);
+	}
 
 	return b;
 }
@@ -97,7 +99,11 @@ void * BR_RESIDENT_ENTRY BrMemCalloc(int nelems, br_size_t size, br_uint_8 type)
 	ASSERT(fw.mem->allocate != NULL);
 
 	b = fw.mem->allocate(size * nelems,type);
-	BrMemSet(b,0,size * nelems);
+
+
+	if (b != NULL || size * nelems != 0) {
+		BrMemSet(b,0,size * nelems);
+	}
 
 #if MEM_LOG
 	BrLogPrintf("BrMemCalloc(%d,%d,%s) = %p\n",nelems, size, fw.resource_class_index[type]->identifier ,b);

--- a/core/fw/mem.c
+++ b/core/fw/mem.c
@@ -30,7 +30,7 @@ void * BR_RESIDENT_ENTRY BrMemAllocate(br_size_t size, br_uint_8 type)
 	/*
 	 * Clear block
 	 */
-	if (b != NULL || size != 0) {
+	if (size != 0) {
 		BrMemSet(b,0,size);
 	}
 
@@ -101,7 +101,7 @@ void * BR_RESIDENT_ENTRY BrMemCalloc(int nelems, br_size_t size, br_uint_8 type)
 	b = fw.mem->allocate(size * nelems,type);
 
 
-	if (b != NULL || size * nelems != 0) {
+	if (size * nelems != 0) {
 		BrMemSet(b,0,size * nelems);
 	}
 

--- a/drivers/softrend/v1model.c
+++ b/drivers/softrend/v1model.c
@@ -926,7 +926,7 @@ static br_error V1Model_Render
 		 * Merge opacity into alpha byte of colour
 		 */
 		scache.colour = renderer->state.surface.colour & 0xFFFFFF;
-		scache.colour |= BrScalarToInt(BR_CONST_MUL(renderer->state.surface.opacity,256)) << 24;
+		scache.colour |= (br_uint_32)BrScalarToInt(BR_CONST_MUL(renderer->state.surface.opacity,256)) << 24;
 
 		/*
 		 * Make sure base primitive block is hooked up to the right place


### PR DESCRIPTION
- shifting a number into the sign bit of a signed integer is undefined behavior, so use undefined int for the MSB bits
- malloc of ubsan returns NULL when allocating 0 bytes, and doing memset/memcpy with a null src/dst pointer is apparently undefined behavior