### PR TITLE
Fix pentprim asm translation mismatches

### DIFF
--- a/drivers/pentprim/common.h
+++ b/drivers/pentprim/common.h
@@ -89,5 +89,19 @@ static void MAKE_N_LOW_BIT_MASK(uint32_t *name, int n) {
         goto label; \
     }
 
+/*
+ * x86-style effective address for word accesses:
+ * [base_off + 2*idx], with idx interpreted as raw 32-bit register bits.
+ */
+#define X86_WORD_EA(base_off, idx_bits) \
+    ((uint32_t)(base_off) + (((uint32_t)(idx_bits)) << 1))
+
+#define DEPTH_READ16(base_ptr, base_off, idx_bits) \
+    (*(uint16_t *)((uint8_t *)(base_ptr) + X86_WORD_EA((base_off), (idx_bits))))
+
+#define DEPTH_WRITE16(base_ptr, base_off, idx_bits, val16) \
+    do { \
+        *(uint16_t *)((uint8_t *)(base_ptr) + X86_WORD_EA((base_off), (idx_bits))) = (uint16_t)(val16); \
+    } while (0)
 
 #endif

--- a/drivers/pentprim/fpsetup.c
+++ b/drivers/pentprim/fpsetup.c
@@ -30,8 +30,8 @@ uint16_t fp_extended_cw = 0x137f;
 int      sort_table_1[] = {1, 2, 0, 0, 0, 0, 2, 1};
 int      sort_table_0[] = {0, 0, 0, 2, 1, 0, 1, 2};
 int      sort_table_2[] = {2, 1, 0, 1, 2, 0, 0, 0};
-uint32_t flip_table[8]  = {0x000000000, 0x080000000, 0x080000000, 0x000000000,
-                           0x080000000, 0x000000000, 0x000000000, 0x080000000};
+uint32_t flip_table[8]  = {0x00000000, 0x80000000, 0x80000000, 0x00000000,
+                           0x80000000, 0x00000000, 0x00000000, 0x80000000};
 
 #define MASK_MANTISSA   0x007fffff
 #define IMPLICIT_ONE    1 << 23
@@ -111,7 +111,7 @@ static int SETUP_FLOAT(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2)
     RCL_1(ebx.v);
 
 
-    CMP(edx.v, ecx.v)
+    CMP(edx.v, ecx.v);
     RCL_1(ebx.v); // ebx now has 3 bit number characterising the order of the vertices.
 
     eax.v = sort_table_0[ebx.v];
@@ -133,7 +133,7 @@ static int SETUP_FLOAT(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2)
     ebp.v &= MASK_MANTISSA;
     ecx.v >>= 23;
     ebp.v |= IMPLICIT_ONE;
-    ebp.v >>= ecx.l;
+    ebp.v >>= (ecx.l & 31);
     esi.float_val = ((brp_vertex *)ebx.ptr_v)->comp_f[C_SY];
     ecx.v = EXPONENT_OFFSET;
     ecx.v -= esi.v;
@@ -141,7 +141,7 @@ static int SETUP_FLOAT(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2)
     ecx.v >>= 23;
     esi.v |= IMPLICIT_ONE;
     // shr		 ebp,cl				; ESI = y_m
-    esi.v >>= ecx.l;
+    esi.v >>= (ecx.l & 31);
 
     edi.float_val = ((brp_vertex *)edx.ptr_v)->comp_f[C_SY];
     ecx.v = EXPONENT_OFFSET;
@@ -150,7 +150,7 @@ static int SETUP_FLOAT(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2)
     ecx.v >>= 23;
     edi.v |= IMPLICIT_ONE;
     // shr		 edi,cl				; edi = y_b
-    edi.v >>= ecx.l;
+    edi.v >>= (ecx.l & 31);
 
     // Catch special cases of empty top or bottom trapezoids
 
@@ -682,7 +682,7 @@ void SETUP_FLOAT_PARAM(int comp, char *param /*unused*/, fp64_t *s_p, fp64_t *d_
         //mov(x86_op_reg(esi), x86_op_mem32(s_p));
         esi.v = s_p->dword_low;
         // 			xor		esi,080000000h
-        esi.v ^= 0x080000000;
+        esi.v ^= 0x80000000;
         // 			mov		dword ptr s_p,esi
         s_p->dword_low = esi.v;
         // endif
@@ -1115,11 +1115,14 @@ static void ARBITRARY_SETUP()
 
 void SETUP_FLOAT_COLOUR(brp_vertex *v0) {
     // fld dword ptr [eax+4*C_I]
-	// fadd fp_conv_d16
-	// fstp qword ptr temporary_intensity
-	// mov bl, byte ptr temporary_intensity+2
-	// mov byte ptr workspace.colour,bl
-    workspace.colour = (int)v0->comp_f[C_I];
+    FLD(v0->comp_f[C_I]);
+    // fadd fp_conv_d16
+    FADD(fp_conv_d16);
+    // fstp qword ptr temporary_intensity
+    FSTP64(&temporary_intensity);
+    // mov bl, byte ptr temporary_intensity+2
+    // mov byte ptr workspace.colour,bl
+    workspace.colour = ((uint8_t *)&temporary_intensity)[2];
 }
 
 

--- a/drivers/pentprim/fti8_piz.c
+++ b/drivers/pentprim/fti8_piz.c
@@ -107,9 +107,6 @@ scan_loop:
     // mov	ebx,edx				; need same junk in high word of old and new z
     ebx.v = edx.v;
 
-    // TOOD: not sure here
-    x86_state.cf = 0;
-
     // ; eax = i
 	// ; ebx = old z, dz
 	// ; ecx =	di
@@ -123,7 +120,7 @@ pixel_loop:
     // adc_&dirn	edx,0		; carry into integer part of z
     ADC_D(edx.v, 0, dirn);
     // mov	bl,[edi+ebp*2]		; fetch old z
-    ebx.short_low = ((uint16_t *)work.depth.base)[edi.v / 2 + ebp.int_val];
+    ebx.short_low = DEPTH_READ16(work.depth.base, edi.v, ebp.v);
 
     // add_&dirn	eax,ecx		; step i
     ADD_SET_CF_D(eax.v, ecx.v, dirn);
@@ -142,7 +139,7 @@ pixel_loop:
     }
 
     // mov	[edi+ebp*2],dx		; store pixel and depth (prefix cannot be avoided since
-    ((uint16_t *)work.depth.base)[edi.v / 2 + ebp.int_val] = edx.short_low;
+    DEPTH_WRITE16(work.depth.base, edi.v, ebp.v, edx.short_low);
     // mov	[esi+ebp],al		; two byte writes would fill the write buffers)
     ((uint8_t *)work.colour.base)[esi.v + ebp.v] = eax.l;
 
@@ -150,11 +147,13 @@ pixel_behind:
 
     // add_&dirn	edx,ebx		; step z
     // inc_&dirn	ebp			; increment (negative) counter/offset
+    // IMPORTANT: add/sub must update CF because next iteration starts with
+    // adc_&dirn edx,0 (carry into integer part of z)
     if (dirn == DIR_F) {
-        edx.v += ebx.v;
+        ADD_AND_SET_CF(edx.v, ebx.v);
         ebp.v++;
     } else {
-        edx.v -= ebx.v;
+        SUB_AND_SET_CF(edx.v, ebx.v);
         ebp.v--;
     }
 
@@ -248,10 +247,7 @@ no_pixels:
     }
 }
 
-
-
 void BR_ASM_CALL TriangleRender_ZI_I8_D16(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2) {
-
     // ; Get pointers to vertex structures
 	// ;
 	// 	mov	eax,pvertex_0

--- a/drivers/pentprim/fti8pizp.c
+++ b/drivers/pentprim/fti8pizp.c
@@ -253,7 +253,7 @@ nodraw:
 
     // cmp		edi,ecx
     // jg_&dirn    ScanlineRender_ZPT&fogging&&blend&_I8_D16_&size&_&dirn&_done
-    if (dirn == DIR_F && edi.ptr_v > ecx.ptr_v || dirn == DIR_B && edi.ptr_v < ecx.ptr_v) {
+    if (dirn == DIR_F && edi.v > ecx.v || dirn == DIR_B && edi.v < ecx.v) {
         return;
     }
 
@@ -343,7 +343,7 @@ inculoop:
         ebx.v -= edx.v;
         // cmp		ebx,edx
         // jge		inculoop
-        if (ebx.int_val > edx.int_val) {
+        if (ebx.int_val >= edx.int_val) {
             goto inculoop;
         }
         // mov		work.tsl.du_numerator,edi
@@ -357,11 +357,11 @@ inculoop:
 	    // ;
         // jl_&udirn	doneu
         if (udirn == eScan_direction_i && ebx.int_val < 0) {
-            goto nodecu;
+            goto doneu;
         } else if (udirn == eScan_direction_b && ebx.int_val > 0) {
-            goto nodecu;
+            goto doneu;
         } else if (udirn == eScan_direction_d && ebx.int_val >= 0) {
-            goto nodecu;
+            goto doneu;
         }
 
         // ; Adjust u
@@ -718,7 +718,7 @@ nodraw:
     ADD_D(ebp.ptr_8, 2, dirn);
     // cmp		edi,ecx
     // jg_&dirn    ScanlineRender_ZPT&fogging&&blend&_I8_D16_&size&_&dirn&_done
-    if (dirn == DIR_F && edi.ptr_v > ecx.ptr_v || dirn == DIR_B && edi.ptr_v < ecx.ptr_v) {
+    if (dirn == DIR_F && edi.v > ecx.v || dirn == DIR_B && edi.v < ecx.v) {
         return;
     }
 
@@ -817,7 +817,7 @@ inculoop:
         ebx.v -= edx.v;
         // cmp		ebx,edx
         // jge		inculoop
-        if (ebx.int_val > edx.int_val) {
+        if (ebx.int_val >= edx.int_val) {
             goto inculoop;
         }
         // mov		work.tsl.du_numerator,edi
@@ -831,11 +831,11 @@ inculoop:
 	    // ;
         // jl_&udirn	doneu
         if (udirn == eScan_direction_i && ebx.int_val < 0) {
-            goto nodecu;
+            goto doneu;
         } else if (udirn == eScan_direction_b && ebx.int_val > 0) {
-            goto nodecu;
+            goto doneu;
         } else if (udirn == eScan_direction_d && ebx.int_val >= 0) {
-            goto nodecu;
+            goto doneu;
         }
 
         // ; Adjust u
@@ -1940,16 +1940,16 @@ void BR_ASM_CALL TriangleRender_ZPTI_I8_D16_32(brp_block *block, brp_vertex *v0,
     // mov		work.tsl.dz,ecx
     work.tsl.dz = ecx.v;
 
-    // shl		al,2
+    // shl		al,3
     eax.l <<= 3;
     // mov		work.tsl._di,edx
     work.tsl.di = edx.v;
 
-    // shr		eax,2
+    // shr		eax,3
     eax.v >>= 3;
     // mov		ebx,work.pq.grad_x
     ebx.v = work.pq.grad_x;
-    // and		eax,63*65
+    // and		eax,31*33
     eax.v &= 31*33;
     // mov		work.tsl.ddenominator,ebx
     work.tsl.ddenominator = ebx.v;

--- a/drivers/pentprim/pfpsetup.c
+++ b/drivers/pentprim/pfpsetup.c
@@ -141,7 +141,7 @@ static int SETUP_FLOAT(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2)
 	RCL_1(ebx.v);
     CMP(edx.v, eax.v);
     RCL_1(ebx.v);
-    CMP(edx.v, ecx.v)
+    CMP(edx.v, ecx.v);
     RCL_1(ebx.v); // ebx now has 3 bit number characterising the order of the vertices.
 
     eax.v = sort_table_0[ebx.v];
@@ -163,7 +163,7 @@ static int SETUP_FLOAT(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2)
     ebp.v &= MASK_MANTISSA;
     ecx.v >>= 23;
     ebp.v |= IMPLICIT_ONE;
-    ebp.v >>= ecx.l;
+    ebp.v >>= (ecx.l & 31);
     esi.float_val = ((brp_vertex *)ebx.ptr_v)->comp_f[C_SY];
     ecx.v = EXPONENT_OFFSET;
     ecx.v -= esi.v;
@@ -171,7 +171,7 @@ static int SETUP_FLOAT(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2)
     ecx.v >>= 23;
     esi.v |= IMPLICIT_ONE;
     // shr		 ebp,cl				; ESI = y_m
-    esi.v >>= ecx.l;
+    esi.v >>= (ecx.l & 31);
 
     edi.float_val = ((brp_vertex *)edx.ptr_v)->comp_f[C_SY];
     ecx.v = EXPONENT_OFFSET;
@@ -180,7 +180,7 @@ static int SETUP_FLOAT(brp_vertex *v0, brp_vertex *v1, brp_vertex *v2)
     ecx.v >>= 23;
     edi.v |= IMPLICIT_ONE;
     // shr		 edi,cl				; edi = y_b
-    edi.v >>= ecx.l;
+    edi.v >>= (ecx.l & 31);
 
     // Catch special cases of empty top or bottom trapezoids
 
@@ -645,7 +645,7 @@ int SETUP_FLOAT_CHECK_PERSPECTIVE_CHEAT() {
 	// mov		edx,[ebp].comp_f[C_W*4]
     edx.float_val = BRP_VERTEX(ebp)->comp_f[C_W];
 	// cmp		ebx,eax
-    CMP(ebx.float_val, eax.float_val);
+    CMP(ebx.v, eax.v);
 
 	// fld		st(0)						;	xrange	xrange	yrange
     FLD_ST(0);
@@ -655,12 +655,12 @@ int SETUP_FLOAT_CHECK_PERSPECTIVE_CHEAT() {
 	// rcl		ecx,1
     RCL_1(ecx.v);
 	// cmp		edx,eax
-    CMP(edx.float_val, eax.float_val);
+    CMP(edx.v, eax.v);
 
 	// rcl		ecx,1
     RCL_1(ecx.v);
 	// cmp		edx,ebx
-    CMP(edx.float_val, ebx.float_val);
+    CMP(edx.v, ebx.v);
 
 	// fstp	xr_yr
     FSTP(&xr_yr);
@@ -746,7 +746,7 @@ xrange_larger:
 	// ;
     // cmp		ecx,edx
     CMP(ecx.v, edx.v);
-    int jb_flag = ecx.v < edx.v;
+    int jb_flag = x86_state.cf;
     // mov		ecx,workspace_v1
     ecx.ptr_v = workspace.v1;
 

--- a/drivers/pentprim/zb8.c
+++ b/drivers/pentprim/zb8.c
@@ -64,7 +64,7 @@ drawPixel:
     // mov dl,[ebp+2*ecx]
     // ;The following line needs some more experimentation to prove its usefullness in real application
     // mov dh,[ebp+2*ecx+1]
-    edx.short_low = ((uint16_t *)work.depth.base)[ebp.v / 2 + ecx.int_val];
+    edx.short_low = DEPTH_READ16(work.depth.base, ebp.v, ecx.v);
     // cmp eax,edx
     // ja noPlot
     if (eax.v > edx.v) {
@@ -72,7 +72,7 @@ drawPixel:
     }
     // ; writes
     // mov [ebp+2*ecx],ax
-    ((uint16_t *)work.depth.base)[ebp.v / 2 + ecx.int_val] = eax.short_low;
+    DEPTH_WRITE16(work.depth.base, ebp.v, ecx.v, eax.short_low);
     // mov [edi+ecx],bl
     ((uint8_t *)work.colour.base)[edi.v + ecx.v] = ebx.l;
 noPlot:
@@ -225,7 +225,7 @@ void BR_ASM_CALL TriangleRender_Z_I8_D16(brp_block *block, brp_vertex *v0, brp_v
     // mov edx,workspace.d_z_x
     edx.v = workspace.d_z_x;
     // cmp edx,80000000
-    CMP(edx.v, 80000000);
+    CMP(edx.v, 0x80000000);
     // adc edx,-1
     ADC(edx.v, -1);
     // ror edx,16

--- a/drivers/pentprim/zb8awtm.c
+++ b/drivers/pentprim/zb8awtm.c
@@ -83,7 +83,7 @@ static inline void PER_SCAN_ZT(int32_t *halfCount, char wrap_flag, uint32_t *min
 vBelowRetest:
     // 	cmp eax,work.texture.base
     // 	jae vPerLineNoWrapNegative
-    if(eax.int_val >= WORK_TEXTURE_BASE) {
+    if(eax.v >= (uint32_t)WORK_TEXTURE_BASE) {
         goto vPerLineNoWrapNegative;
     }
 
@@ -95,7 +95,7 @@ vPerLineNoWrapNegative:
 vAboveRetest:
     // 	cmp eax,workspaceA.vUpperBound
     // 	jb vPerLineNoWrapPositive
-    if(eax.int_val < workspaceA.vUpperBound) {
+    if(eax.v < workspaceA.vUpperBound) {
         goto vPerLineNoWrapPositive;
     }
     // 	sub eax,work.texture._size
@@ -239,7 +239,7 @@ static inline void PER_SCAN_ZTI(int32_t *halfCount, char wrap_flag, uint32_t *mi
 vBelowRetest:
     // 	cmp eax,work.texture.base
     // 	jae vPerLineNoWrapNegative
-    if(eax.int_val >= WORK_TEXTURE_BASE) {
+    if(eax.v >= (uint32_t)WORK_TEXTURE_BASE) {
         goto vPerLineNoWrapNegative;
     }
 
@@ -251,7 +251,7 @@ vPerLineNoWrapNegative:
 vAboveRetest:
     // 	cmp eax,workspaceA.vUpperBound
     // 	jb vPerLineNoWrapPositive
-    if(eax.int_val < workspaceA.vUpperBound) {
+    if(eax.v < workspaceA.vUpperBound) {
         goto vPerLineNoWrapPositive;
     }
     // 	sub eax,work.texture._size
@@ -384,7 +384,7 @@ drawLine:
 
 drawPixel:
     // 	mov bx,[ebp+2*ecx]
-    ebx.short_low = ((uint16_t *)work.depth.base)[ebp.v / 2 + ecx.int_val];
+    ebx.short_low = DEPTH_READ16(work.depth.base, ebp.v, ecx.v);
     // 	mov dx,word ptr workspace.c_z+2
     edx.short_low = workspace.c_z >> 16;
 
@@ -439,7 +439,7 @@ drawPixel:
         // else
         } else {
             //     mov [ebp+2*ecx],dx
-            ((uint16_t *)work.depth.base)[ebp.v / 2 + ecx.int_val] = edx.short_low;
+            DEPTH_WRITE16(work.depth.base, ebp.v, ecx.v, edx.short_low);
             // 	   mov [edi+ecx],bl
             ((uint8_t *)work.colour.base)[edi.v + ecx.v] = ebx.l;
         // endif
@@ -468,7 +468,7 @@ noPlot:
 vBelowRetest:
     // 	cmp esi,work.texture.base
     // 	jae vPerPixelNoWrapNegative
-    if(esi.int_val >= WORK_TEXTURE_BASE) {
+    if(esi.v >= (uint32_t)WORK_TEXTURE_BASE) {
         goto vPerPixelNoWrapNegative;
     }
     // 	add esi,work.texture._size
@@ -479,7 +479,7 @@ vPerPixelNoWrapNegative:
 vAboveRetest:
     // 	cmp esi,workspaceA.vUpperBound
     // 	jb vPerPixelNoWrapPositive
-    if(esi.int_val < workspaceA.vUpperBound) {
+    if(esi.v < workspaceA.vUpperBound) {
         goto vPerPixelNoWrapPositive;
     }
     // 	sub esi,work.texture._size
@@ -618,7 +618,7 @@ drawLine:
 
 drawPixel:
     // 	mov bx,[ebp+2*ecx]
-    ebx.short_low = ((uint16_t *)work.depth.base)[ebp.v / 2 + ecx.int_val];
+    ebx.short_low = DEPTH_READ16(work.depth.base, ebp.v, ecx.v);
     // 	mov dx,word ptr workspace.c_z+2
     edx.short_low = workspace.c_z >> 16;
 
@@ -684,7 +684,7 @@ drawPixel:
             // mov bl,byte ptr [eax+ebx]
             ebx.l = ((uint8_t *)work.shade_table)[ebx.v];
 	        // mov [ebp+2*ecx],dx
-            ((uint16_t *)work.depth.base)[ebp.v / 2 + ecx.int_val] = edx.short_low;
+            DEPTH_WRITE16(work.depth.base, ebp.v, ecx.v, edx.short_low);
             // 	   mov [edi+ecx],bl
             ((uint8_t *)work.colour.base)[edi.v + ecx.v] = ebx.l;
         // endif
@@ -719,7 +719,7 @@ noPlot:
 vBelowRetest:
     // 	cmp esi,work.texture.base
     // 	jae vPerPixelNoWrapNegative
-    if(esi.int_val >= WORK_TEXTURE_BASE) {
+    if(esi.v >= (uint32_t)WORK_TEXTURE_BASE) {
         goto vPerPixelNoWrapNegative;
     }
     // 	add esi,work.texture._size
@@ -730,7 +730,7 @@ vPerPixelNoWrapNegative:
 vAboveRetest:
     // 	cmp esi,workspaceA.vUpperBound
     // 	jb vPerPixelNoWrapPositive
-    if(esi.int_val < workspaceA.vUpperBound) {
+    if(esi.v < workspaceA.vUpperBound) {
         goto vPerPixelNoWrapPositive;
     }
     // 	sub esi,work.texture._size

--- a/drivers/pentprim/zb8p2lit.c
+++ b/drivers/pentprim/zb8p2lit.c
@@ -77,7 +77,7 @@ drawPixel:
     // and edi,mask shl pow2
     edi.v &= (mask << pow2);
     // mov dl,[ebp+2*ecx]
-    edx.v = ((uint16_t *)work.depth.base)[ebp.v / 2 + ecx.int_val]; //grab both bytes at once
+    edx.v = DEPTH_READ16(work.depth.base, ebp.v, ecx.v); //grab both bytes at once
     // or eax,edi
     eax.v |= edi.v;
     // mov dh,[ebp+2*ecx+1]
@@ -105,7 +105,7 @@ drawPixel:
         goto noPlot;
     }
     // mov [ebp+2*ecx],bx ;two cycles
-    ((uint16_t *)work.depth.base)[ebp.v / 2 + ecx.int_val] = ebx.short_low;
+    DEPTH_WRITE16(work.depth.base, ebp.v, ecx.v, ebx.short_low);
     // mov [esi+ecx],al
     ((uint8_t *)work.colour.base)[esi.v + ecx.v] = eax.l;
 
@@ -329,7 +329,7 @@ void BR_ASM_CALL TriangleRender_ZTI_I8_D16_POW2(brp_block *block, int pow2, int 
 // 	mov workspace.d_xm_f,ebx
 	workspace.d_xm_f = ebx.v;
 // 	cmp edx,80000000
-	CMP(edx.v, 80000000);
+	CMP(edx.v, 0x80000000);
 
 // 	adc edx,-1
 	ADC(edx.v, -1);

--- a/drivers/pentprim/zb8p2ulb.c
+++ b/drivers/pentprim/zb8p2ulb.c
@@ -72,7 +72,7 @@ drawPixel:
 	// 	shr esi,16-pow2
 	esi.v >>= (16 - pow2);
 	// 	mov bl,[ebp+2*ecx]
-	ebx.v = ((uint16_t *)work.depth.base)[ebp.v / 2 + ecx.int_val];
+	ebx.v = DEPTH_READ16(work.depth.base, ebp.v, ecx.v);
 
 	// 	shr eax,16
 	eax.v >>= 16;
@@ -109,7 +109,7 @@ drawPixel:
 
 	// 	mov [ebp+2*ecx],dl
 	// 	mov [ebp+2*ecx+1],dh
-	((uint16_t *)work.depth.base)[ebp.v / 2 + ecx.int_val] = edx.short_low;
+	DEPTH_WRITE16(work.depth.base, ebp.v, ecx.v, edx.short_low);
 
 	// and eax,0ffffh
 	eax.v &= 0xffff;
@@ -350,7 +350,7 @@ void BR_ASM_CALL TriangleRender_ZTB_I8_D16_POW2(brp_block *block, int pow2, int 
 // 	mov workspace.d_xm_f,ebx
 	workspace.d_xm_f = ebx.v;
 // 	cmp edx,80000000
-	CMP(edx.v, 80000000);
+	CMP(edx.v, 0x80000000);
 
 // 	adc edx,-1
 	ADC(edx.v, -1);

--- a/drivers/pentprim/zb8p2unl.c
+++ b/drivers/pentprim/zb8p2unl.c
@@ -80,7 +80,7 @@ drawPixel:
 // 	shr esi,16-pow2
 	esi.v >>= (16 - pow2);
 // 	mov bl,[ebp+2*ecx]
-	ebx.v = ((uint16_t *)work.depth.base)[ebp.v / 2 + ecx.int_val];
+	ebx.v = DEPTH_READ16(work.depth.base, ebp.v, ecx.v);
 
 // 	shr eax,16
 	eax.v >>= 16;
@@ -98,9 +98,9 @@ drawPixel:
 
 // 	cmp dx,bx ;two cycles
 // 	ja noPlot
-    if(edx.short_low > ebx.short_low) {
-        goto noPlot;
-    }
+	if(edx.short_low > ebx.short_low) {
+		goto noPlot;
+	}
 
 
 // 	mov al,[esi+eax]
@@ -114,7 +114,7 @@ drawPixel:
 
 // 	mov [ebp+2*ecx],dl
 // 	mov [ebp+2*ecx+1],dh
-	((uint16_t *)work.depth.base)[ebp.v / 2 + ecx.int_val] = edx.short_low;
+	DEPTH_WRITE16(work.depth.base, ebp.v, ecx.v, edx.short_low);
 // 	mov [edi+ecx],al
 	((uint8_t *)work.colour.base)[edi.v + ecx.v] = eax.l;
 
@@ -346,7 +346,7 @@ void BR_ASM_CALL TriangleRender_ZT_I8_D16_POW2(brp_block *block, int pow2, int s
 // 	mov workspace.d_xm_f,ebx
 	workspace.d_xm_f = ebx.v;
 // 	cmp edx,80000000
-	CMP(edx.v, 80000000);
+	CMP(edx.v, 0x80000000);
 
 // 	adc edx,-1
 	ADC(edx.v, -1);

--- a/x86emu/include/x86emu.h
+++ b/x86emu/include/x86emu.h
@@ -266,26 +266,37 @@ extern x86_reg eax, ebx, ecx, edx, ebp, edi, esi;
 
 #define RCL_1(val) \
     do { \
-    int msb = val & 0x80000000; \
+    uint32_t old_cf = x86_state.cf & 1u; \
+    uint32_t new_cf = ((val) >> 31) & 1u; \
     /* rotate CF flag into lsb */ \
-    val = (val << 1) + x86_state.cf; \
-    /* rotate msb into CF */ \
-    x86_state.cf = msb; \
+    val = ((val) << 1) | old_cf; \
+    /* rotate msb into CF (single bit) */ \
+    x86_state.cf = new_cf; \
     } while(0)
 
 #define ADD_AND_SET_CF(val1, val2) \
     val1 += val2; \
-	x86_state.cf = val1 < val2;
+    x86_state.cf = val1 < val2;
 
 #define SUB_AND_SET_CF(val1, val2) \
     x86_state.cf = val1 < val2; \
     val1 -= val2;
 
 #define ADC(val1, val2) \
-    val1 += val2 + x86_state.cf;
+    do { \
+    uint32_t _cf = x86_state.cf & 1u; \
+    uint64_t _sum = (uint64_t)(uint32_t)(val1) + (uint32_t)(val2) + _cf; \
+    val1 = _sum; \
+    x86_state.cf = (_sum >> 32) & 1u; \
+    } while (0)
 
 #define SBB(val1, val2) \
-    val1 = val1 - (val2 + x86_state.cf);
+    do { \
+    uint32_t _cf = x86_state.cf & 1u; \
+    uint64_t _sub = (uint64_t)(uint32_t)(val2) + _cf; \
+    x86_state.cf = (uint32_t)(val1) < _sub; \
+    val1 = (uint32_t)(val1) - (uint32_t)_sub; \
+    } while (0)
 
 #define ROR16(dest) \
     x86_state.x86_swap = dest.short_low; \


### PR DESCRIPTION
## Summary
- tighten x86 emulation helpers used by the pentprim asm-to-C translations
- fix pentprim depth-buffer addressing and related translation mismatches

## Notes
- Used `codex` to help find the depth write bug (although still with a lot of manual effort)
<img width="752" height="620" alt="Screenshot 2026-05-14 at 8 58 09 PM" src="https://github.com/user-attachments/assets/af6238be-2f5d-4e6a-b7a9-5f20d737e7f3" />

fixes https://github.com/dethrace-labs/dethrace/issues/531

